### PR TITLE
add dtreerpo algorithm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -232,4 +232,5 @@ opencompass/tmp
 __pycache__/
 *.py[cod]
 *$py.class
-
+outputs/
+ckpts/

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ DARE is a work in progress, we plan to support more models and algorithm for tra
 
 
 ## 📢 News
+- [2026-03-23]: Support d-TreeRPO algorithm for LLaDA and Dream models.
 - [2026-03-16]: Support bgpo and ebpo for LLaDA2.X.
 - [2026-03-13]: Fix bugs in SDAR SGLang rollout and dp actor.
 - [2026-03-12]: Support sp for SDAR family, LLaDA2.0 and 2.1.
@@ -131,10 +132,6 @@ pip install flash-attn==2.8.3 --no-build-isolation
 # install from whl
 # wget https://github.com/Dao-AILab/flash-attention/releases/download/v2.8.3/flash_attn-2.8.3+cu12torch2.8cxx11abiFALSE-cp310-cp310-linux_x86_64.whl
 # pip install flash_attn-2.8.3+cu12torch2.8cxx11abiFALSE-cp310-cp310-linux_x86_64.whl
-
-# You can go to https://flashattn.dev/ to find the compiled FlashAttention .whl that corresponds to your Python, PyTorch, and CUDA versions.
-# After download the .whl, install it
-pip install flash_attn-2.8.x+cu12xtorch2.x-cp3xx-cp3xx-linux_x86_64.whl # For example
 ```
 
 Build evaluation vitual environment:
@@ -224,6 +221,12 @@ bash recipe/run_coupled_grpo_dream_7b_instruct.sh --task math # use Fast-dLLM fo
 
 # online rl for sdar_8b_chat
 bash recipe/run_bgpo_sdar_8b_chat.sh --task math # use lmdeploy engine for rollout acceleration
+
+# d-TreeRPO for llada_8b_instruct
+bash recipe/llada/run_dtreerpo_llada_8b_instruct.sh --task math
+
+# d-TreeRPO for dream_7b_instruct
+bash recipe/dream/run_dtreerpo_dream_7b_instruct.sh --task math
 ```
 
 ### 🚀 DPO/VRPO Quick Start
@@ -325,6 +328,7 @@ If you want to add more benchmarks, models, or custom datasets, please refer to 
 | **spg** | [2510.09541](https://arxiv.org/pdf/2510.09541) | [facebookresearch/SPG](https://github.com/facebookresearch/SPG) |
 | **bgpo** | [2510.11683](https://arxiv.org/pdf/2510.11683) | [THU-KEG/BGPO](https://github.com/THU-KEG/BGPO) |
 | **ebpo** | [2602.08676](https://arxiv.org/pdf/2602.08676) | [inclusionAI/LLaDA2.X](https://github.com/inclusionAI/LLaDA2.X) (closed source) |
+| **d-TreeRPO** | [2512.09675](https://arxiv.org/pdf/2512.09675) | [d-TreeRPO](https://github.com/your-repo/d-TreeRPO) |
 
 
 ## 📈 Performance
@@ -407,10 +411,9 @@ If you find our work useful, please consider citing:
 
 We thank the open-source community for their wonderful work and valuable contributions:
 - Models Source: [GSAI-ML](https://huggingface.co/GSAI-ML), [inclusionAI](https://huggingface.co/inclusionAI), [Dream-org](https://huggingface.co/Dream-org), [JetLM](https://huggingface.co/JetLM), [huggingface](https://huggingface.co/) for model supply or hosting
-- Algorithm: [d1](https://github.com/dllm-reasoning/d1), [CJ-GRPO](https://github.com/yjyddq/EOSER-ASS-RL), [MDPO](https://github.com/autonomousvision/mdpo), [Coupled-GRPO](https://github.com/apple/ml-diffucoder), [SPG](https://github.com/facebookresearch/SPG), [BGPO](https://github.com/THU-KEG/BGPO), [LLaDA2.X](https://github.com/inclusionAI/LLaDA2.X)
+- Algorithm: [d1](https://github.com/dllm-reasoning/d1), [CJ-GRPO](https://github.com/yjyddq/EOSER-ASS-RL), [MDPO](https://github.com/autonomousvision/mdpo), [Coupled-GRPO](https://github.com/apple/ml-diffucoder), [SPG](https://github.com/facebookresearch/SPG), [BGPO](https://github.com/THU-KEG/BGPO), [LLaDA2.X](https://github.com/inclusionAI/LLaDA2.X), [d-TreeRPO](https://arxiv.org/abs/2512.09675)
 - Training Framework: [verl](https://github.com/volcengine/verl), [BGPO](https://github.com/THU-KEG/BGPO), [Dream](https://github.com/DreamLM/Dream), [dFactory](https://github.com/inclusionAI/dFactory)
 - Inference Acceleration/Engine: [Fast-dLLM](https://github.com/NVlabs/Fast-dLLM), [lmdeploy](https://github.com/InternLM/lmdeploy), [SGLang](https://github.com/sgl-project/sglang)
 - Evaluation Framework: [opencompass](https://github.com/open-compass/opencompass), [LLaDA](https://github.com/ML-GSAI/LLaDA)
-- Environment Dependencies: [verl](https://github.com/volcengine/verl), [opencompass](https://github.com/open-compass/opencompass), [flash-attn](https://flashattn.dev/)
 
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,10 @@ pip install flash-attn==2.8.3 --no-build-isolation
 # install from whl
 # wget https://github.com/Dao-AILab/flash-attention/releases/download/v2.8.3/flash_attn-2.8.3+cu12torch2.8cxx11abiFALSE-cp310-cp310-linux_x86_64.whl
 # pip install flash_attn-2.8.3+cu12torch2.8cxx11abiFALSE-cp310-cp310-linux_x86_64.whl
+
+# You can go to https://flashattn.dev/ to find the compiled FlashAttention .whl that corresponds to your Python, PyTorch, and CUDA versions.
+# After download the .whl, install it
+pip install flash_attn-2.8.x+cu12xtorch2.x-cp3xx-cp3xx-linux_x86_64.whl # For example
 ```
 
 Build evaluation vitual environment:

--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ If you want to add more benchmarks, models, or custom datasets, please refer to 
 | **spg** | [2510.09541](https://arxiv.org/pdf/2510.09541) | [facebookresearch/SPG](https://github.com/facebookresearch/SPG) |
 | **bgpo** | [2510.11683](https://arxiv.org/pdf/2510.11683) | [THU-KEG/BGPO](https://github.com/THU-KEG/BGPO) |
 | **ebpo** | [2602.08676](https://arxiv.org/pdf/2602.08676) | [inclusionAI/LLaDA2.X](https://github.com/inclusionAI/LLaDA2.X) (closed source) |
-| **d-TreeRPO** | [2512.09675](https://arxiv.org/pdf/2512.09675) | [d-TreeRPO](https://github.com/your-repo/d-TreeRPO) |
+| **d-TreeRPO** | [2512.09675](https://arxiv.org/pdf/2512.09675) | [d-TreeRPO](https://github.com/THU-BPM/d-TreeRPO) |
 
 
 ## 📈 Performance

--- a/README.md
+++ b/README.md
@@ -419,5 +419,5 @@ We thank the open-source community for their wonderful work and valuable contrib
 - Training Framework: [verl](https://github.com/volcengine/verl), [BGPO](https://github.com/THU-KEG/BGPO), [Dream](https://github.com/DreamLM/Dream), [dFactory](https://github.com/inclusionAI/dFactory)
 - Inference Acceleration/Engine: [Fast-dLLM](https://github.com/NVlabs/Fast-dLLM), [lmdeploy](https://github.com/InternLM/lmdeploy), [SGLang](https://github.com/sgl-project/sglang)
 - Evaluation Framework: [opencompass](https://github.com/open-compass/opencompass), [LLaDA](https://github.com/ML-GSAI/LLaDA)
-
+- Environment Dependencies: [verl](https://github.com/volcengine/verl), [opencompass](https://github.com/open-compass/opencompass), [flash-attn](https://flashattn.dev/)
 

--- a/recipe/dream/run_dtreerpo_dream_7b_instruct.sh
+++ b/recipe/dream/run_dtreerpo_dream_7b_instruct.sh
@@ -1,0 +1,228 @@
+#!/bin/bash
+set -x
+export HYDRA_FULL_ERROR=1
+export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True  # Add memory fragmentation optimization
+export CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
+export WANDB_MODE="offline"
+export HF_HUB_OFFLINE=1
+export TORCHDYNAMO_DISABLE=1
+export SWANLAB_API_KEY=Z2wdWHeNCtCCnPAXsLzX6
+export SWANLAB_MODE=cloud
+
+echo "[INFO] Cleaning up old Ray..."
+ray stop --force || true
+rm -rf /tmp/ray || true
+
+# arguments parsing
+while [[ $# -gt 0 ]]; do
+  key="$1"
+  case $key in
+    --model)
+      model="$2"
+      shift; shift
+      ;;
+    --model_path)
+      model_path="$2"
+      shift; shift
+      ;;
+    --task)
+      task="$2"
+      shift; shift
+      ;;
+    --algorithm)
+      algorithm="$2"
+      shift; shift
+      ;;
+    --engine)
+      engine="$2"
+      shift; shift
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+algorithm=${algorithm:-dtreerpo}
+model=${model:-dream}
+model_path=${model_path:-models/Dream-v0-Instruct-7B}
+engine=${engine:-hf}
+
+# validate task
+valid_tasks=("math" "code" "sudoku" "countdown")
+if [[ ! " ${valid_tasks[@]} " =~ " ${task} " ]]; then
+    echo "Error: Invalid task '$task'"
+    echo "Supported tasks: ${valid_tasks[*]}"
+    exit 1
+fi
+
+# validate model
+valid_models=("llada" "dream")
+if [[ ! " ${valid_models[@]} " =~ " ${model} " ]]; then
+    echo "Error: Invalid model '$model'"
+    echo "Supported models: ${valid_models[*]}"
+    exit 1
+fi
+
+# Unified hyperparams matching d-TreeRPO reference
+max_prompt_length=512
+max_response_length=256
+num_diffusion_steps=128
+total_epoch=10
+
+if [ $task == "math" ]; then
+    train_files="['data/preprocessed/rl/train/math_1.parquet','data/preprocessed/rl/train/gsm8k_1.parquet']"
+    val_files="['data/preprocessed/rl/test/math500_1.parquet','data/preprocessed/rl/test/gsm8k_1.parquet']"
+elif [ $task == "code" ]; then
+    train_files="['data/preprocessed/rl/train/lcbv5-K8_1.parquet','data/preprocessed/rl/train/primeintellect-K8_1.parquet','data/preprocessed/rl/train/taco-K8_1.parquet']"
+    val_files="['data/preprocessed/rl/test/mbpp_1.parquet','data/preprocessed/rl/test/humaneval_1.parquet','data/preprocessed/rl/test/humanevalplus_1.parquet']"
+elif [ $task == "countdown" ]; then
+    train_files="['data/preprocessed/rl/train/countdown-n20000_1.parquet']"
+    val_files="['data/preprocessed/rl/test/countdown_1.parquet']"
+elif [ $task == "sudoku" ]; then
+    train_files="['data/preprocessed/rl/train/sudoku-n20000_1.parquet']"
+    val_files="['data/preprocessed/rl/test/sudoku_1.parquet']"
+fi
+
+# Set token IDs based on model
+case $model in
+    "llada")
+        mask_token_id=126336
+        pad_token_id=126081
+        ;;
+    "dream")
+        mask_token_id=151666
+        pad_token_id=151643
+        ;;
+    *)
+        echo "Error: Unknown model '$model'"
+        exit 1
+        ;;
+esac
+
+# parameters setting
+n_gpus_per_node=$(echo $CUDA_VISIBLE_DEVICES | tr "," "\n" | wc -l)
+batch_size=16  # batch_size must be greater than the number of GPUs used
+n_rollout=1    # d-TreeRPO uses tree search instead of standard rollout
+lr=3e-5
+ppo_micro_batch_size_per_gpu=1
+train_temperature=0.9
+
+# d-TreeRPO specific parameters
+tree_branch_factor=4          # T: branches per node
+tree_contraction_factor=2     # s: spacing factor
+num_tree_samples=4            # full trees per prompt
+enable_self_distillation=True # self-distillation loss
+sd_lambda_max=3e-3            # lambda_max
+sd_gamma=2.0                  # gamma
+sd_tau_max=2.0                # tau_max
+sd_beta=0.7                   # beta
+
+# diffusion related parameters
+val_num_diffusion_steps=$max_response_length
+block_length=32
+
+timestamp=$(date +"%Y%m%d_%H%M%S")
+project_name="DARE"
+exp_name="${model}-${task}-dtreerpo-T${tree_branch_factor}-s${tree_contraction_factor}-bsz${batch_size}-prompt${max_prompt_length}-response${max_response_length}-step${num_diffusion_steps}-lr${lr}-temp${train_temperature}-gpu${n_gpus_per_node}-${timestamp}"
+ckpt_dir=./ckpts/${project_name}/${exp_name}
+log_dir=./logs/${project_name}/${exp_name}
+mkdir -p ${ckpt_dir}
+mkdir -p ${log_dir}
+
+python3 -m verl.trainer.dllm_main_ppo \
+    algorithm.adv_estimator=grpo \
+    +algorithm.name=dtreerpo \
+    reward_model.reward_manager=dllm \
+    +reward_model.reward_kwargs.overlong_buffer_cfg.enable=False \
+    +reward_model.reward_kwargs.max_resp_len=$max_response_length \
+    data.train_files="$train_files" \
+    data.val_files="$val_files" \
+    data.train_batch_size=$batch_size \
+    data.val_batch_size=64 \
+    data.max_prompt_length=$max_prompt_length \
+    data.max_response_length=$max_response_length \
+    data.filter_overlong_prompts=True \
+    data.truncation="error" \
+    data.trust_remote_code=True \
+    +actor_rollout_ref.algorithm.name=dtreerpo \
+    +actor_rollout_ref.model.name=${model} \
+    actor_rollout_ref.model.path=$model_path \
+    actor_rollout_ref.actor.optim.lr=$lr \
+    actor_rollout_ref.actor.optim.weight_decay=0.1 \
+    +actor_rollout_ref.actor.optim.betas="[0.9,0.99]" \
+    actor_rollout_ref.actor.optim.warmup_style=constant \
+    actor_rollout_ref.actor.optim.lr_warmup_steps_ratio=0.0001 \
+    actor_rollout_ref.model.use_remove_padding=True \
+    actor_rollout_ref.actor.strategy=fsdp2 \
+    actor_rollout_ref.actor.ppo_mini_batch_size=$batch_size \
+    actor_rollout_ref.actor.use_dynamic_bsz=True \
+    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=1 \
+    actor_rollout_ref.actor.ppo_max_token_len_per_gpu=5120 \
+    actor_rollout_ref.actor.use_kl_loss=True \
+    actor_rollout_ref.actor.kl_loss_coef=0.01 \
+    actor_rollout_ref.actor.kl_loss_type=low_var_kl \
+    actor_rollout_ref.actor.entropy_coeff=0.0 \
+    actor_rollout_ref.actor.clip_ratio=0.4 \
+    actor_rollout_ref.actor.grad_clip=0.2 \
+    actor_rollout_ref.actor.ppo_epochs=12 \
+    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=$ppo_micro_batch_size_per_gpu \
+    actor_rollout_ref.actor.loss_agg_mode=token-mean \
+    actor_rollout_ref.model.lora_rank=128 \
+    actor_rollout_ref.model.lora_alpha=64 \
+    +actor_rollout_ref.model.lora_dropout=0.05 \
+    actor_rollout_ref.model.target_modules=all-linear \
+    actor_rollout_ref.model.enable_gradient_checkpointing=False \
+    actor_rollout_ref.model.trust_remote_code=True \
+    +actor_rollout_ref.model.attn_implementation="flash_attention_2" \
+    +actor_rollout_ref.model.baseline="${model}-${task}-dtreerpo" \
+    actor_rollout_ref.actor.fsdp_config.param_offload=False \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=False \
+    +actor_rollout_ref.actor.fsdp_config.wrap_policy.transformer_layer_cls_to_wrap=[DreamDecoderLayer] \
+    +actor_rollout_ref.actor.mc_num=1 \
+    +actor_rollout_ref.actor.n_l=1 \
+    +actor_rollout_ref.actor.cfg_scale=0.0 \
+    +actor_rollout_ref.actor.baseline="${model}-${task}-dtreerpo" \
+    +actor_rollout_ref.actor.tree_branch_factor=$tree_branch_factor \
+    +actor_rollout_ref.actor.tree_contraction_factor=$tree_contraction_factor \
+    +actor_rollout_ref.actor.num_tree_samples=$num_tree_samples \
+    +actor_rollout_ref.actor.enable_self_distillation=$enable_self_distillation \
+    +actor_rollout_ref.actor.sd_lambda_max=$sd_lambda_max \
+    +actor_rollout_ref.actor.sd_gamma=$sd_gamma \
+    +actor_rollout_ref.actor.sd_tau_max=$sd_tau_max \
+    +actor_rollout_ref.actor.sd_beta=$sd_beta \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=1 \
+    actor_rollout_ref.rollout.name=hf \
+    +actor_rollout_ref.rollout.use_cache=True \
+    +actor_rollout_ref.rollout.dual_cache=False \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.9 \
+    actor_rollout_ref.rollout.n=$n_rollout \
+    actor_rollout_ref.rollout.temperature=$train_temperature \
+    actor_rollout_ref.rollout.do_sample=True \
+    actor_rollout_ref.rollout.val_kwargs.do_sample=True \
+    actor_rollout_ref.rollout.val_kwargs.n=1 \
+    actor_rollout_ref.rollout.val_kwargs.temperature=0.0 \
+    actor_rollout_ref.rollout.val_kwargs.top_p=0.95 \
+    +actor_rollout_ref.rollout.val_kwargs.num_diffusion_steps=$val_num_diffusion_steps \
+    actor_rollout_ref.rollout.max_num_batched_tokens=11000 \
+    actor_rollout_ref.rollout.enable_chunked_prefill=True \
+    +actor_rollout_ref.rollout.num_diffusion_steps=$num_diffusion_steps \
+    +actor_rollout_ref.rollout.block_length=$block_length \
+    +actor_rollout_ref.rollout.mc_num=1 \
+    +actor_rollout_ref.rollout.n_l=1 \
+    +actor_rollout_ref.rollout.cfg_scale=0.0 \
+    actor_rollout_ref.ref.fsdp_config.param_offload=True \
+    algorithm.use_kl_in_reward=False \
+    trainer.critic_warmup=0 \
+    trainer.logger='["console","swanlab"]' \
+    trainer.project_name=$project_name \
+    trainer.experiment_name=$exp_name \
+    trainer.val_before_train=False \
+    trainer.n_gpus_per_node=$n_gpus_per_node \
+    trainer.nnodes=1 \
+    trainer.default_local_dir=$ckpt_dir \
+    trainer.save_freq=20 \
+    trainer.test_freq=20 \
+    trainer.total_epochs=$total_epoch \
+    custom_reward_function.path="verl/utils/reward_score/__init__.py" \
+    custom_reward_function.name="dllm_rm"

--- a/recipe/dream/run_dtreerpo_dream_7b_instruct.sh
+++ b/recipe/dream/run_dtreerpo_dream_7b_instruct.sh
@@ -6,8 +6,8 @@ export CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
 export WANDB_MODE="offline"
 export HF_HUB_OFFLINE=1
 export TORCHDYNAMO_DISABLE=1
-export SWANLAB_API_KEY=Z2wdWHeNCtCCnPAXsLzX6
-export SWANLAB_MODE=cloud
+export SWANLAB_API_KEY=
+export SWANLAB_MODE=
 
 echo "[INFO] Cleaning up old Ray..."
 ray stop --force || true

--- a/recipe/llada/run_dtreerpo_llada_8b_instruct.sh
+++ b/recipe/llada/run_dtreerpo_llada_8b_instruct.sh
@@ -1,0 +1,228 @@
+#!/bin/bash
+set -x
+export HYDRA_FULL_ERROR=1
+export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True  # Add memory fragmentation optimization
+export CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
+export WANDB_MODE="offline"
+export HF_HUB_OFFLINE=1
+export TORCHDYNAMO_DISABLE=1
+export SWANLAB_API_KEY=Z2wdWHeNCtCCnPAXsLzX6
+export SWANLAB_MODE=cloud
+
+echo "[INFO] Cleaning up old Ray..."
+ray stop --force || true
+rm -rf /tmp/ray || true
+
+# arguments parsing
+while [[ $# -gt 0 ]]; do
+  key="$1"
+  case $key in
+    --model)
+      model="$2"
+      shift; shift
+      ;;
+    --model_path)
+      model_path="$2"
+      shift; shift
+      ;;
+    --task)
+      task="$2"
+      shift; shift
+      ;;
+    --algorithm)
+      algorithm="$2"
+      shift; shift
+      ;;
+    --engine)
+      engine="$2"
+      shift; shift
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+algorithm=${algorithm:-dtreerpo}
+model=${model:-llada}
+model_path=${model_path:-models/LLaDA-8B-Instruct}
+engine=${engine:-hf}
+
+# validate task
+valid_tasks=("math" "code" "sudoku" "countdown")
+if [[ ! " ${valid_tasks[@]} " =~ " ${task} " ]]; then
+    echo "Error: Invalid task '$task'"
+    echo "Supported tasks: ${valid_tasks[*]}"
+    exit 1
+fi
+
+# validate model
+valid_models=("llada" "dream")
+if [[ ! " ${valid_models[@]} " =~ " ${model} " ]]; then
+    echo "Error: Invalid model '$model'"
+    echo "Supported models: ${valid_models[*]}"
+    exit 1
+fi
+
+# Unified hyperparams matching d-TreeRPO reference
+max_prompt_length=512
+max_response_length=256
+num_diffusion_steps=128
+total_epoch=10
+
+if [ $task == "math" ]; then
+    train_files="['data/preprocessed/rl/train/math_1.parquet','data/preprocessed/rl/train/gsm8k_1.parquet']"
+    val_files="['data/preprocessed/rl/test/math500_1.parquet','data/preprocessed/rl/test/gsm8k_1.parquet']"
+elif [ $task == "code" ]; then
+    train_files="['data/preprocessed/rl/train/lcbv5-K8_1.parquet','data/preprocessed/rl/train/primeintellect-K8_1.parquet','data/preprocessed/rl/train/taco-K8_1.parquet']"
+    val_files="['data/preprocessed/rl/test/mbpp_1.parquet','data/preprocessed/rl/test/humaneval_1.parquet','data/preprocessed/rl/test/humanevalplus_1.parquet']"
+elif [ $task == "countdown" ]; then
+    train_files="['data/preprocessed/rl/train/countdown-n20000_1.parquet']"
+    val_files="['data/preprocessed/rl/test/countdown_1.parquet']"
+elif [ $task == "sudoku" ]; then
+    train_files="['data/preprocessed/rl/train/sudoku-n20000_1.parquet']"
+    val_files="['data/preprocessed/rl/test/sudoku_1.parquet']"
+fi
+
+# Set token IDs based on model
+case $model in
+    "llada")
+        mask_token_id=126336
+        pad_token_id=126081
+        ;;
+    "dream")
+        mask_token_id=151666
+        pad_token_id=151643
+        ;;
+    *)
+        echo "Error: Unknown model '$model'"
+        exit 1
+        ;;
+esac
+
+# parameters setting
+n_gpus_per_node=$(echo $CUDA_VISIBLE_DEVICES | tr "," "\n" | wc -l)
+batch_size=16  # batch_size must be greater than the number of GPUs used
+n_rollout=1    # d-TreeRPO uses tree search instead of standard rollout
+lr=3e-5
+ppo_micro_batch_size_per_gpu=1
+train_temperature=0.9
+
+# d-TreeRPO specific parameters
+tree_branch_factor=4          # T: branches per node
+tree_contraction_factor=2     # s: spacing factor
+num_tree_samples=4            # full trees per prompt
+enable_self_distillation=True # self-distillation loss
+sd_lambda_max=3e-3            # lambda_max
+sd_gamma=2.0                  # gamma
+sd_tau_max=2.0                # tau_max
+sd_beta=0.7                   # beta
+
+# diffusion related parameters
+val_num_diffusion_steps=$max_response_length
+block_length=32
+
+timestamp=$(date +"%Y%m%d_%H%M%S")
+project_name="DARE"
+exp_name="${model}-${task}-dtreerpo-T${tree_branch_factor}-s${tree_contraction_factor}-bsz${batch_size}-prompt${max_prompt_length}-response${max_response_length}-step${num_diffusion_steps}-lr${lr}-temp${train_temperature}-gpu${n_gpus_per_node}-${timestamp}"
+ckpt_dir=./ckpts/${project_name}/${exp_name}
+log_dir=./logs/${project_name}/${exp_name}
+mkdir -p ${ckpt_dir}
+mkdir -p ${log_dir}
+
+python3 -m verl.trainer.dllm_main_ppo \
+    algorithm.adv_estimator=grpo \
+    +algorithm.name=dtreerpo \
+    reward_model.reward_manager=dllm \
+    +reward_model.reward_kwargs.overlong_buffer_cfg.enable=False \
+    +reward_model.reward_kwargs.max_resp_len=$max_response_length \
+    data.train_files="$train_files" \
+    data.val_files="$val_files" \
+    data.train_batch_size=$batch_size \
+    data.val_batch_size=64 \
+    data.max_prompt_length=$max_prompt_length \
+    data.max_response_length=$max_response_length \
+    data.filter_overlong_prompts=True \
+    data.truncation="error" \
+    data.trust_remote_code=True \
+    +actor_rollout_ref.algorithm.name=dtreerpo \
+    +actor_rollout_ref.model.name=${model} \
+    actor_rollout_ref.model.path=$model_path \
+    actor_rollout_ref.actor.optim.lr=$lr \
+    actor_rollout_ref.actor.optim.weight_decay=0.1 \
+    +actor_rollout_ref.actor.optim.betas="[0.9,0.99]" \
+    actor_rollout_ref.actor.optim.warmup_style=constant \
+    actor_rollout_ref.actor.optim.lr_warmup_steps_ratio=0.0001 \
+    actor_rollout_ref.model.use_remove_padding=True \
+    actor_rollout_ref.actor.strategy=fsdp2 \
+    actor_rollout_ref.actor.ppo_mini_batch_size=$batch_size \
+    actor_rollout_ref.actor.use_dynamic_bsz=True \
+    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=1 \
+    actor_rollout_ref.actor.ppo_max_token_len_per_gpu=5120 \
+    actor_rollout_ref.actor.use_kl_loss=True \
+    actor_rollout_ref.actor.kl_loss_coef=0.01 \
+    actor_rollout_ref.actor.kl_loss_type=low_var_kl \
+    actor_rollout_ref.actor.entropy_coeff=0.0 \
+    actor_rollout_ref.actor.clip_ratio=0.4 \
+    actor_rollout_ref.actor.grad_clip=0.2 \
+    actor_rollout_ref.actor.ppo_epochs=12 \
+    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=$ppo_micro_batch_size_per_gpu \
+    actor_rollout_ref.actor.loss_agg_mode=token-mean \
+    actor_rollout_ref.model.lora_rank=128 \
+    actor_rollout_ref.model.lora_alpha=64 \
+    +actor_rollout_ref.model.lora_dropout=0.05 \
+    actor_rollout_ref.model.target_modules=all-linear \
+    actor_rollout_ref.model.enable_gradient_checkpointing=False \
+    actor_rollout_ref.model.trust_remote_code=True \
+    +actor_rollout_ref.model.attn_implementation="flash_attention_2" \
+    +actor_rollout_ref.model.baseline="${model}-${task}-dtreerpo" \
+    actor_rollout_ref.actor.fsdp_config.param_offload=False \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=False \
+    +actor_rollout_ref.actor.fsdp_config.wrap_policy.transformer_layer_cls_to_wrap=[LLaDALlamaBlock] \
+    +actor_rollout_ref.actor.mc_num=1 \
+    +actor_rollout_ref.actor.n_l=1 \
+    +actor_rollout_ref.actor.cfg_scale=0.0 \
+    +actor_rollout_ref.actor.baseline="${model}-${task}-dtreerpo" \
+    +actor_rollout_ref.actor.tree_branch_factor=$tree_branch_factor \
+    +actor_rollout_ref.actor.tree_contraction_factor=$tree_contraction_factor \
+    +actor_rollout_ref.actor.num_tree_samples=$num_tree_samples \
+    +actor_rollout_ref.actor.enable_self_distillation=$enable_self_distillation \
+    +actor_rollout_ref.actor.sd_lambda_max=$sd_lambda_max \
+    +actor_rollout_ref.actor.sd_gamma=$sd_gamma \
+    +actor_rollout_ref.actor.sd_tau_max=$sd_tau_max \
+    +actor_rollout_ref.actor.sd_beta=$sd_beta \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=1 \
+    actor_rollout_ref.rollout.name=hf \
+    +actor_rollout_ref.rollout.use_cache=True \
+    +actor_rollout_ref.rollout.dual_cache=False \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.9 \
+    actor_rollout_ref.rollout.n=$n_rollout \
+    actor_rollout_ref.rollout.temperature=$train_temperature \
+    actor_rollout_ref.rollout.do_sample=True \
+    actor_rollout_ref.rollout.val_kwargs.do_sample=True \
+    actor_rollout_ref.rollout.val_kwargs.n=1 \
+    actor_rollout_ref.rollout.val_kwargs.temperature=0.0 \
+    actor_rollout_ref.rollout.val_kwargs.top_p=0.95 \
+    +actor_rollout_ref.rollout.val_kwargs.num_diffusion_steps=$val_num_diffusion_steps \
+    actor_rollout_ref.rollout.max_num_batched_tokens=11000 \
+    actor_rollout_ref.rollout.enable_chunked_prefill=True \
+    +actor_rollout_ref.rollout.num_diffusion_steps=$num_diffusion_steps \
+    +actor_rollout_ref.rollout.block_length=$block_length \
+    +actor_rollout_ref.rollout.mc_num=1 \
+    +actor_rollout_ref.rollout.n_l=1 \
+    +actor_rollout_ref.rollout.cfg_scale=0.0 \
+    actor_rollout_ref.ref.fsdp_config.param_offload=True \
+    algorithm.use_kl_in_reward=False \
+    trainer.critic_warmup=0 \
+    trainer.logger='["console","swanlab"]' \
+    trainer.project_name=$project_name \
+    trainer.experiment_name=$exp_name \
+    trainer.val_before_train=False \
+    trainer.n_gpus_per_node=$n_gpus_per_node \
+    trainer.nnodes=1 \
+    trainer.default_local_dir=$ckpt_dir \
+    trainer.save_freq=20 \
+    trainer.test_freq=20 \
+    trainer.total_epochs=$total_epoch \
+    custom_reward_function.path="verl/utils/reward_score/__init__.py" \
+    custom_reward_function.name="dllm_rm"

--- a/recipe/llada/run_dtreerpo_llada_8b_instruct.sh
+++ b/recipe/llada/run_dtreerpo_llada_8b_instruct.sh
@@ -6,8 +6,8 @@ export CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
 export WANDB_MODE="offline"
 export HF_HUB_OFFLINE=1
 export TORCHDYNAMO_DISABLE=1
-export SWANLAB_API_KEY=Z2wdWHeNCtCCnPAXsLzX6
-export SWANLAB_MODE=cloud
+export SWANLAB_API_KEY=
+export SWANLAB_MODE=
 
 echo "[INFO] Cleaning up old Ray..."
 ray stop --force || true

--- a/verl/trainer/ppo/dllm_ray_trainer.py
+++ b/verl/trainer/ppo/dllm_ray_trainer.py
@@ -5,6 +5,7 @@ from verl.trainer.ppo.dllm_metric_utils import (
     process_validation_metrics,
 )
 from verl.trainer.ppo.mdpo_algos import compute_step_wise_advantage, select_top_k_steps
+from verl.trainer.ppo.dtreerpo_algos import compute_dtreerpo_rewards_and_segments
 
 
 class DLLMRayPPOTrainer(RayPPOTrainer):
@@ -120,195 +121,6 @@ class DLLMRayPPOTrainer(RayPPOTrainer):
                     metric_dict[pfx] = metric_val
 
         return metric_dict
-
-    def _dtreerpo_compute_rewards_and_segments(self, tree_output, batch, gen_batch):
-        """
-        Given tree search output, compute rewards at leaf nodes, propagate upward,
-        compute local advantages, and construct training segments.
-        """
-        import torch
-
-        tree_batch = tree_output.batch
-        meta = tree_output.meta_info
-        prompt_length = meta["prompt_length"]
-        num_leaves = meta["num_leaves"]
-        num_nodes = meta["num_nodes"]
-        branch_points = meta["branch_points"]
-
-        # After DP concat, dim0 = total_batch_size.
-        # Tensors: (total_batch, num_nodes/num_leaves, ...)
-        # Tree structure is the same for all batch items; take from first item.
-        batch_size = tree_batch["node_generations"].size(0)  # total batch size after DP gather
-
-        node_generations = tree_batch["node_generations"]  # (B, num_nodes, seq_len)
-        node_steps = tree_batch["node_steps"][0]           # (num_nodes,) - same for all batch items
-        node_is_leaf = tree_batch["node_is_leaf"][0]       # (num_nodes,)
-        node_parent_idx = tree_batch["node_parent_idx"][0] # (num_nodes,)
-        node_children_idx = tree_batch["node_children_idx"][0]  # (num_nodes, max_children)
-
-        leaf_input_ids_bt = tree_batch["leaf_input_ids"]   # (B, num_leaves, seq_len)
-        leaf_responses_bt = tree_batch["leaf_responses"]   # (B, num_leaves, resp_len)
-        leaf_attn_bt = tree_batch["leaf_attn"]             # (B, num_leaves, seq_len)
-
-        # Transpose node_generations to (num_nodes, B, seq_len) for tree processing
-        node_generations = node_generations.permute(1, 0, 2).contiguous()  # (num_nodes, B, seq_len)
-
-        seq_len = node_generations.size(-1)
-        response_length = seq_len - prompt_length
-        device = node_generations.device
-
-        # Flatten leaf data to (num_leaves * B, ...) for reward computation
-        leaf_input_ids = leaf_input_ids_bt.permute(1, 0, 2).contiguous().reshape(-1, seq_len)  # (num_leaves * B, seq_len)
-        leaf_responses = leaf_responses_bt.permute(1, 0, 2).contiguous().reshape(-1, response_length)
-        leaf_attn = leaf_attn_bt.permute(1, 0, 2).contiguous().reshape(-1, seq_len)
-
-        # Compute rewards for leaf nodes
-        leaf_total = num_leaves * batch_size
-        # Expand non_tensor_batch to match leaf batch size before passing to DataProto
-        expanded_non_tensors = {}
-        if batch.non_tensor_batch is not None:
-            for key, val in batch.non_tensor_batch.items():
-                if isinstance(val, np.ndarray):
-                    # Repeat each element num_leaves times (leaves are ordered leaf-major: all batch items for leaf0, then leaf1, etc.)
-                    expanded_non_tensors[key] = np.tile(val, num_leaves)[:leaf_total]
-                else:
-                    expanded_non_tensors[key] = val
-
-        leaf_batch = DataProto.from_dict(
-            tensors={
-                "input_ids": leaf_input_ids,
-                "responses": leaf_responses,
-                "prompts": leaf_input_ids[:, :prompt_length],
-                "attention_mask": leaf_attn,
-                "position_ids": leaf_attn.cumsum(dim=-1) - 1,
-            },
-            non_tensors=expanded_non_tensors,
-        )
-
-        reward_tensor, reward_extra_infos_dict = compute_reward(leaf_batch, self.reward_fn)
-        leaf_rewards = reward_tensor.sum(dim=-1)  # (num_leaves * batch_size,)
-
-        # Assign rewards to leaf nodes: reshape to (num_leaves, batch_size)
-        leaf_rewards_mat = leaf_rewards.reshape(num_leaves, batch_size)
-
-        # Create value vectors for all nodes
-        node_value_vecs = torch.zeros(num_nodes, batch_size, device=device)
-
-        # Assign leaf values
-        leaf_idx = 0
-        for i in range(num_nodes):
-            if node_is_leaf[i]:
-                node_value_vecs[i] = leaf_rewards_mat[leaf_idx]
-                leaf_idx += 1
-
-        # Bottom-up propagation: process steps from lowest to highest
-        for step in sorted(branch_points[:-1]):
-            for i in range(num_nodes):
-                if node_steps[i] == step and i > 0:  # skip root (i=0)
-                    children = node_children_idx[i]
-                    valid_children = children[children >= 0]
-                    if len(valid_children) > 0:
-                        child_vals = torch.stack([node_value_vecs[c] for c in valid_children])
-                        node_value_vecs[i] = torch.nanmean(child_vals, dim=0)
-
-        # Root propagation
-        root_children = node_children_idx[0]
-        valid_root_children = root_children[root_children >= 0]
-        if len(valid_root_children) > 0:
-            root_child_vals = torch.stack([node_value_vecs[c] for c in valid_root_children])
-            node_value_vecs[0] = torch.nanmean(root_child_vals, dim=0)
-
-        # Compute local advantages for each non-root node
-        node_local_adv = torch.zeros(num_nodes, batch_size, device=device)
-        for i in range(1, num_nodes):
-            parent = node_parent_idx[i].item()
-            siblings = node_children_idx[parent]
-            valid_siblings = siblings[(siblings >= 0) & (siblings != i)]
-            if len(valid_siblings) > 0:
-                sib_vals = torch.stack([node_value_vecs[s] for s in valid_siblings])
-                sib_mean = torch.nanmean(sib_vals, dim=0)
-            else:
-                sib_mean = torch.zeros(batch_size, device=device)
-            node_local_adv[i] = node_value_vecs[i] - sib_mean
-
-        # Build training segments
-        all_parent_ids = []
-        all_child_ids = []
-        all_attention_masks = []
-        all_local_advantages = []
-        all_group_ids = []
-
-        group_key_to_id = {}
-        next_gid = 0
-
-        response_length_cfg = self.config.actor_rollout_ref.rollout.get("response_length")
-        for i in range(1, num_nodes):
-            parent_idx_val = node_parent_idx[i].item()
-            parent_gen = node_generations[parent_idx_val]   # (batch_size, seq_len)
-            child_gen = node_generations[i]                 # (batch_size, seq_len)
-            adv = node_local_adv[i]                         # (batch_size,)
-
-            # Build attention mask
-            attn = torch.ones(batch_size, seq_len, dtype=torch.long, device=device)
-
-            for b in range(batch_size):
-                key = (parent_idx_val, b)
-                gid = group_key_to_id.get(key)
-                if gid is None:
-                    gid = next_gid
-                    next_gid += 1
-                    group_key_to_id[key] = gid
-                all_group_ids.append(gid)
-
-            all_parent_ids.append(parent_gen)
-            all_child_ids.append(child_gen)
-            all_attention_masks.append(attn)
-            all_local_advantages.append(adv)
-
-        if not all_parent_ids:
-            return None, {"dtreerpo/mean_leaf_reward": 0.0}
-
-        parent_ids_cat = torch.cat(all_parent_ids, dim=0)
-        child_ids_cat = torch.cat(all_child_ids, dim=0)
-        attn_cat = torch.cat(all_attention_masks, dim=0)
-        adv_cat = torch.cat(all_local_advantages, dim=0)
-        group_ids_cat = torch.tensor(all_group_ids, dtype=torch.long, device=device)
-        prompt_length_t = torch.tensor([prompt_length], dtype=torch.long, device=device).expand(parent_ids_cat.size(0))
-
-        from tensordict import TensorDict
-        segments = DataProto.from_dict(
-            tensors={
-                "parent_ids": parent_ids_cat,
-                "child_ids": child_ids_cat,
-                "attention_mask": attn_cat,
-                "local_advantages": adv_cat,
-                "group_ids": group_ids_cat,
-                "prompt_length": prompt_length_t,
-                # Dummy fields for metrics compatibility
-                "prompts": parent_ids_cat[:, :prompt_length],
-                "responses": child_ids_cat[:, prompt_length:],
-                "token_level_scores": torch.zeros(parent_ids_cat.size(0), response_length_cfg, device=device),
-                "token_level_rewards": torch.zeros(parent_ids_cat.size(0), response_length_cfg, device=device),
-                "response_mask": attn_cat[:, -response_length_cfg:],
-            },
-        )
-        segments.meta_info["micro_batch_size"] = self.config.actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu
-        segments.meta_info["temperature"] = self.config.actor_rollout_ref.rollout.temperature
-
-        dtreerpo_metrics = {
-            "dtreerpo/mean_leaf_reward": leaf_rewards.mean().item(),
-            "dtreerpo/mean_root_value": node_value_vecs[0].mean().item(),
-            "dtreerpo/mean_local_adv": adv_cat.mean().item(),
-            "dtreerpo/num_segments": parent_ids_cat.size(0),
-        }
-
-        # Also set reward tensors on batch for standard metrics
-        # Use leaf rewards averaged per prompt as the reward signal
-        mean_leaf_reward_per_prompt = leaf_rewards_mat.mean(dim=0)  # (batch_size,)
-        if reward_extra_infos_dict:
-            batch.non_tensor_batch.update({k: np.array(v) for k, v in reward_extra_infos_dict.items()})
-
-        return segments, dtreerpo_metrics
 
     def fit(self):
         """
@@ -775,33 +587,22 @@ class DLLMRayPPOTrainer(RayPPOTrainer):
                     elif self.config.algorithm.name == "dtreerpo":
                         # d-TreeRPO: tree search, reward propagation, local advantage, actor update
                         with _timer("dtreerpo_tree_search", timing_raw):
-                            tree_search_batch = DataProto.from_dict(
-                                tensors={
-                                    "input_ids": gen_batch.batch["input_ids"],
-                                    "attention_mask": gen_batch.batch["attention_mask"],
-                                },
-                            )
-                            tree_search_batch.meta_info.update({
-                                "response_length": self.config.actor_rollout_ref.rollout.get("response_length"),
-                                "num_diffusion_steps": self.config.actor_rollout_ref.rollout.get("num_diffusion_steps"),
-                                "block_length": self.config.actor_rollout_ref.rollout.get("block_length"),
+                            gen_batch.meta_info.update({
                                 "tree_branch_factor": self.config.actor_rollout_ref.actor.get("tree_branch_factor", 4),
                                 "tree_contraction_factor": self.config.actor_rollout_ref.actor.get("tree_contraction_factor", 2),
                                 "num_tree_samples": self.config.actor_rollout_ref.actor.get("num_tree_samples", 4),
-                                "temperature": self.config.actor_rollout_ref.rollout.temperature,
-                                "cfg_scale": self.config.actor_rollout_ref.rollout.get("cfg_scale", 0.0),
                                 "remasking": "low_confidence",
                             })
-                            # Pad for DP
-                            tree_search_batch_padded, tree_pad_size = pad_dataproto_to_divisor(
-                                tree_search_batch, self.actor_rollout_wg.world_size
-                            )
-                            tree_output_padded = self.actor_rollout_wg.tree_search_generate(tree_search_batch_padded)
-                            tree_output = unpad_dataproto(tree_output_padded, pad_size=tree_pad_size)
+                            tree_output = self.actor_rollout_wg.generate_sequences(gen_batch)
 
                         with _timer("dtreerpo_reward_propagation", timing_raw):
-                            dtreerpo_segments, dtreerpo_reward_metrics = self._dtreerpo_compute_rewards_and_segments(
-                                tree_output, batch, gen_batch
+                            dtreerpo_segments, dtreerpo_reward_metrics = compute_dtreerpo_rewards_and_segments(
+                                tree_output=tree_output,
+                                batch=batch,
+                                reward_fn=self.reward_fn,
+                                response_length_cfg=self.config.actor_rollout_ref.rollout.get("response_length"),
+                                micro_batch_size=self.config.actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu,
+                                temperature=self.config.actor_rollout_ref.rollout.temperature,
                             )
                             metrics.update(dtreerpo_reward_metrics)
 

--- a/verl/trainer/ppo/dllm_ray_trainer.py
+++ b/verl/trainer/ppo/dllm_ray_trainer.py
@@ -121,6 +121,195 @@ class DLLMRayPPOTrainer(RayPPOTrainer):
 
         return metric_dict
 
+    def _dtreerpo_compute_rewards_and_segments(self, tree_output, batch, gen_batch):
+        """
+        Given tree search output, compute rewards at leaf nodes, propagate upward,
+        compute local advantages, and construct training segments.
+        """
+        import torch
+
+        tree_batch = tree_output.batch
+        meta = tree_output.meta_info
+        prompt_length = meta["prompt_length"]
+        num_leaves = meta["num_leaves"]
+        num_nodes = meta["num_nodes"]
+        branch_points = meta["branch_points"]
+
+        # After DP concat, dim0 = total_batch_size.
+        # Tensors: (total_batch, num_nodes/num_leaves, ...)
+        # Tree structure is the same for all batch items; take from first item.
+        batch_size = tree_batch["node_generations"].size(0)  # total batch size after DP gather
+
+        node_generations = tree_batch["node_generations"]  # (B, num_nodes, seq_len)
+        node_steps = tree_batch["node_steps"][0]           # (num_nodes,) - same for all batch items
+        node_is_leaf = tree_batch["node_is_leaf"][0]       # (num_nodes,)
+        node_parent_idx = tree_batch["node_parent_idx"][0] # (num_nodes,)
+        node_children_idx = tree_batch["node_children_idx"][0]  # (num_nodes, max_children)
+
+        leaf_input_ids_bt = tree_batch["leaf_input_ids"]   # (B, num_leaves, seq_len)
+        leaf_responses_bt = tree_batch["leaf_responses"]   # (B, num_leaves, resp_len)
+        leaf_attn_bt = tree_batch["leaf_attn"]             # (B, num_leaves, seq_len)
+
+        # Transpose node_generations to (num_nodes, B, seq_len) for tree processing
+        node_generations = node_generations.permute(1, 0, 2).contiguous()  # (num_nodes, B, seq_len)
+
+        seq_len = node_generations.size(-1)
+        response_length = seq_len - prompt_length
+        device = node_generations.device
+
+        # Flatten leaf data to (num_leaves * B, ...) for reward computation
+        leaf_input_ids = leaf_input_ids_bt.permute(1, 0, 2).contiguous().reshape(-1, seq_len)  # (num_leaves * B, seq_len)
+        leaf_responses = leaf_responses_bt.permute(1, 0, 2).contiguous().reshape(-1, response_length)
+        leaf_attn = leaf_attn_bt.permute(1, 0, 2).contiguous().reshape(-1, seq_len)
+
+        # Compute rewards for leaf nodes
+        leaf_total = num_leaves * batch_size
+        # Expand non_tensor_batch to match leaf batch size before passing to DataProto
+        expanded_non_tensors = {}
+        if batch.non_tensor_batch is not None:
+            for key, val in batch.non_tensor_batch.items():
+                if isinstance(val, np.ndarray):
+                    # Repeat each element num_leaves times (leaves are ordered leaf-major: all batch items for leaf0, then leaf1, etc.)
+                    expanded_non_tensors[key] = np.tile(val, num_leaves)[:leaf_total]
+                else:
+                    expanded_non_tensors[key] = val
+
+        leaf_batch = DataProto.from_dict(
+            tensors={
+                "input_ids": leaf_input_ids,
+                "responses": leaf_responses,
+                "prompts": leaf_input_ids[:, :prompt_length],
+                "attention_mask": leaf_attn,
+                "position_ids": leaf_attn.cumsum(dim=-1) - 1,
+            },
+            non_tensors=expanded_non_tensors,
+        )
+
+        reward_tensor, reward_extra_infos_dict = compute_reward(leaf_batch, self.reward_fn)
+        leaf_rewards = reward_tensor.sum(dim=-1)  # (num_leaves * batch_size,)
+
+        # Assign rewards to leaf nodes: reshape to (num_leaves, batch_size)
+        leaf_rewards_mat = leaf_rewards.reshape(num_leaves, batch_size)
+
+        # Create value vectors for all nodes
+        node_value_vecs = torch.zeros(num_nodes, batch_size, device=device)
+
+        # Assign leaf values
+        leaf_idx = 0
+        for i in range(num_nodes):
+            if node_is_leaf[i]:
+                node_value_vecs[i] = leaf_rewards_mat[leaf_idx]
+                leaf_idx += 1
+
+        # Bottom-up propagation: process steps from lowest to highest
+        for step in sorted(branch_points[:-1]):
+            for i in range(num_nodes):
+                if node_steps[i] == step and i > 0:  # skip root (i=0)
+                    children = node_children_idx[i]
+                    valid_children = children[children >= 0]
+                    if len(valid_children) > 0:
+                        child_vals = torch.stack([node_value_vecs[c] for c in valid_children])
+                        node_value_vecs[i] = torch.nanmean(child_vals, dim=0)
+
+        # Root propagation
+        root_children = node_children_idx[0]
+        valid_root_children = root_children[root_children >= 0]
+        if len(valid_root_children) > 0:
+            root_child_vals = torch.stack([node_value_vecs[c] for c in valid_root_children])
+            node_value_vecs[0] = torch.nanmean(root_child_vals, dim=0)
+
+        # Compute local advantages for each non-root node
+        node_local_adv = torch.zeros(num_nodes, batch_size, device=device)
+        for i in range(1, num_nodes):
+            parent = node_parent_idx[i].item()
+            siblings = node_children_idx[parent]
+            valid_siblings = siblings[(siblings >= 0) & (siblings != i)]
+            if len(valid_siblings) > 0:
+                sib_vals = torch.stack([node_value_vecs[s] for s in valid_siblings])
+                sib_mean = torch.nanmean(sib_vals, dim=0)
+            else:
+                sib_mean = torch.zeros(batch_size, device=device)
+            node_local_adv[i] = node_value_vecs[i] - sib_mean
+
+        # Build training segments
+        all_parent_ids = []
+        all_child_ids = []
+        all_attention_masks = []
+        all_local_advantages = []
+        all_group_ids = []
+
+        group_key_to_id = {}
+        next_gid = 0
+
+        response_length_cfg = self.config.actor_rollout_ref.rollout.get("response_length")
+        for i in range(1, num_nodes):
+            parent_idx_val = node_parent_idx[i].item()
+            parent_gen = node_generations[parent_idx_val]   # (batch_size, seq_len)
+            child_gen = node_generations[i]                 # (batch_size, seq_len)
+            adv = node_local_adv[i]                         # (batch_size,)
+
+            # Build attention mask
+            attn = torch.ones(batch_size, seq_len, dtype=torch.long, device=device)
+
+            for b in range(batch_size):
+                key = (parent_idx_val, b)
+                gid = group_key_to_id.get(key)
+                if gid is None:
+                    gid = next_gid
+                    next_gid += 1
+                    group_key_to_id[key] = gid
+                all_group_ids.append(gid)
+
+            all_parent_ids.append(parent_gen)
+            all_child_ids.append(child_gen)
+            all_attention_masks.append(attn)
+            all_local_advantages.append(adv)
+
+        if not all_parent_ids:
+            return None, {"dtreerpo/mean_leaf_reward": 0.0}
+
+        parent_ids_cat = torch.cat(all_parent_ids, dim=0)
+        child_ids_cat = torch.cat(all_child_ids, dim=0)
+        attn_cat = torch.cat(all_attention_masks, dim=0)
+        adv_cat = torch.cat(all_local_advantages, dim=0)
+        group_ids_cat = torch.tensor(all_group_ids, dtype=torch.long, device=device)
+        prompt_length_t = torch.tensor([prompt_length], dtype=torch.long, device=device).expand(parent_ids_cat.size(0))
+
+        from tensordict import TensorDict
+        segments = DataProto.from_dict(
+            tensors={
+                "parent_ids": parent_ids_cat,
+                "child_ids": child_ids_cat,
+                "attention_mask": attn_cat,
+                "local_advantages": adv_cat,
+                "group_ids": group_ids_cat,
+                "prompt_length": prompt_length_t,
+                # Dummy fields for metrics compatibility
+                "prompts": parent_ids_cat[:, :prompt_length],
+                "responses": child_ids_cat[:, prompt_length:],
+                "token_level_scores": torch.zeros(parent_ids_cat.size(0), response_length_cfg, device=device),
+                "token_level_rewards": torch.zeros(parent_ids_cat.size(0), response_length_cfg, device=device),
+                "response_mask": attn_cat[:, -response_length_cfg:],
+            },
+        )
+        segments.meta_info["micro_batch_size"] = self.config.actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu
+        segments.meta_info["temperature"] = self.config.actor_rollout_ref.rollout.temperature
+
+        dtreerpo_metrics = {
+            "dtreerpo/mean_leaf_reward": leaf_rewards.mean().item(),
+            "dtreerpo/mean_root_value": node_value_vecs[0].mean().item(),
+            "dtreerpo/mean_local_adv": adv_cat.mean().item(),
+            "dtreerpo/num_segments": parent_ids_cat.size(0),
+        }
+
+        # Also set reward tensors on batch for standard metrics
+        # Use leaf rewards averaged per prompt as the reward signal
+        mean_leaf_reward_per_prompt = leaf_rewards_mat.mean(dim=0)  # (batch_size,)
+        if reward_extra_infos_dict:
+            batch.non_tensor_batch.update({k: np.array(v) for k, v in reward_extra_infos_dict.items()})
+
+        return segments, dtreerpo_metrics
+
     def fit(self):
         """
         The training loop of PPO.
@@ -186,56 +375,61 @@ class DLLMRayPPOTrainer(RayPPOTrainer):
                 is_last_step = self.global_steps >= self.total_training_steps
 
                 with _timer("step", timing_raw):
-                    # generate a batch
-                    with _timer("gen", timing_raw):
-                        if not self.async_rollout_mode:
-                            gen_batch_output = self.actor_rollout_wg.generate_sequences(gen_batch)
-                        else:
-                            self.async_rollout_manager.wake_up()
-                            gen_batch_output = self.async_rollout_manager.generate_sequences(gen_batch)
-                            self.async_rollout_manager.sleep()
+                    # d-TreeRPO skips standard rollout; tree search handles generation
+                    if self.config.algorithm.name == "dtreerpo":
+                        gen_batch_output = None
+                    else:
+                        # generate a batch
+                        with _timer("gen", timing_raw):
+                            if not self.async_rollout_mode:
+                                gen_batch_output = self.actor_rollout_wg.generate_sequences(gen_batch)
+                            else:
+                                self.async_rollout_manager.wake_up()
+                                gen_batch_output = self.async_rollout_manager.generate_sequences(gen_batch)
+                                self.async_rollout_manager.sleep()
 
-                    if self.config.algorithm.adv_estimator == AdvantageEstimator.REMAX:
-                        with _timer("gen_max", timing_raw):
-                            gen_baseline_batch = deepcopy(gen_batch)
-                            gen_baseline_batch.meta_info["do_sample"] = False
-                            gen_baseline_output = self.actor_rollout_wg.generate_sequences(gen_baseline_batch)
+                    if self.config.algorithm.name != "dtreerpo":
+                        if self.config.algorithm.adv_estimator == AdvantageEstimator.REMAX:
+                            with _timer("gen_max", timing_raw):
+                                gen_baseline_batch = deepcopy(gen_batch)
+                                gen_baseline_batch.meta_info["do_sample"] = False
+                                gen_baseline_output = self.actor_rollout_wg.generate_sequences(gen_baseline_batch)
 
-                            batch = batch.union(gen_baseline_output)
-                            reward_baseline_tensor = self.reward_fn(batch)
-                            reward_baseline_tensor = reward_baseline_tensor.sum(dim=-1)
+                                batch = batch.union(gen_baseline_output)
+                                reward_baseline_tensor = self.reward_fn(batch)
+                                reward_baseline_tensor = reward_baseline_tensor.sum(dim=-1)
 
-                            batch.pop(batch_keys=list(gen_baseline_output.batch.keys()))
+                                batch.pop(batch_keys=list(gen_baseline_output.batch.keys()))
 
-                            batch.batch["reward_baselines"] = reward_baseline_tensor
+                                batch.batch["reward_baselines"] = reward_baseline_tensor
 
-                            del gen_baseline_batch, gen_baseline_output
+                                del gen_baseline_batch, gen_baseline_output
 
-                    batch.non_tensor_batch["uid"] = np.array([str(uuid.uuid4()) for _ in range(len(batch.batch))], dtype=object)
-                    # repeat to align with repeated responses in rollout
-                    batch = batch.repeat(repeat_times=self.config.actor_rollout_ref.rollout.n, interleave=True)
-                    batch = batch.union(gen_batch_output)
+                        batch.non_tensor_batch["uid"] = np.array([str(uuid.uuid4()) for _ in range(len(batch.batch))], dtype=object)
+                        # repeat to align with repeated responses in rollout
+                        batch = batch.repeat(repeat_times=self.config.actor_rollout_ref.rollout.n, interleave=True)
+                        batch = batch.union(gen_batch_output)
 
-                    batch.batch["response_mask"] = compute_response_mask(batch)
-                    # balance the number of valid tokens on each dp rank.
-                    # Note that this breaks the order of data inside the batch.
-                    # Please take care when you implement group based adv computation such as GRPO and rloo
-                    if self.config.trainer.balance_batch:
-                        self._balance_batch(batch, metrics=metrics)
+                        batch.batch["response_mask"] = compute_response_mask(batch)
+                        # balance the number of valid tokens on each dp rank.
+                        # Note that this breaks the order of data inside the batch.
+                        # Please take care when you implement group based adv computation such as GRPO and rloo
+                        if self.config.trainer.balance_batch:
+                            self._balance_batch(batch, metrics=metrics)
 
-                    # compute global_valid tokens
-                    batch.meta_info["global_token_num"] = torch.sum(batch.batch["attention_mask"], dim=-1).tolist()
+                        # compute global_valid tokens
+                        batch.meta_info["global_token_num"] = torch.sum(batch.batch["attention_mask"], dim=-1).tolist()
 
-                    with _timer("reward", timing_raw):
-                        # compute reward model score
-                        if self.use_rm:
-                            reward_tensor = self.rm_wg.compute_rm_score(batch)
-                            batch = batch.union(reward_tensor)
+                        with _timer("reward", timing_raw):
+                            # compute reward model score
+                            if self.use_rm:
+                                reward_tensor = self.rm_wg.compute_rm_score(batch)
+                                batch = batch.union(reward_tensor)
 
-                        if self.config.reward_model.launch_reward_fn_async:
-                            future_reward = compute_reward_async.remote(batch, self.config, self.tokenizer)
-                        else:
-                            reward_tensor, reward_extra_infos_dict = compute_reward(batch, self.reward_fn)
+                            if self.config.reward_model.launch_reward_fn_async:
+                                future_reward = compute_reward_async.remote(batch, self.config, self.tokenizer)
+                            else:
+                                reward_tensor, reward_extra_infos_dict = compute_reward(batch, self.reward_fn)
 
                     if self.config.algorithm.name in ["d1", "coupled-grpo", "bgpo", "ebpo", "spg"]:
                         if self.config.actor_rollout_ref.model.name != "sdar":
@@ -578,10 +772,79 @@ class DLLMRayPPOTrainer(RayPPOTrainer):
                             actor_output_metrics = reduce_metrics(actor_output.meta_info["metrics"])
                             metrics.update(actor_output_metrics)
 
-                    else:
-                        NotImplementedError(f"Unsupported algorithm: {self.config.algorithm.name}")
+                    elif self.config.algorithm.name == "dtreerpo":
+                        # d-TreeRPO: tree search, reward propagation, local advantage, actor update
+                        with _timer("dtreerpo_tree_search", timing_raw):
+                            tree_search_batch = DataProto.from_dict(
+                                tensors={
+                                    "input_ids": gen_batch.batch["input_ids"],
+                                    "attention_mask": gen_batch.batch["attention_mask"],
+                                },
+                            )
+                            tree_search_batch.meta_info.update({
+                                "response_length": self.config.actor_rollout_ref.rollout.get("response_length"),
+                                "num_diffusion_steps": self.config.actor_rollout_ref.rollout.get("num_diffusion_steps"),
+                                "block_length": self.config.actor_rollout_ref.rollout.get("block_length"),
+                                "tree_branch_factor": self.config.actor_rollout_ref.actor.get("tree_branch_factor", 4),
+                                "tree_contraction_factor": self.config.actor_rollout_ref.actor.get("tree_contraction_factor", 2),
+                                "num_tree_samples": self.config.actor_rollout_ref.actor.get("num_tree_samples", 4),
+                                "temperature": self.config.actor_rollout_ref.rollout.temperature,
+                                "cfg_scale": self.config.actor_rollout_ref.rollout.get("cfg_scale", 0.0),
+                                "remasking": "low_confidence",
+                            })
+                            # Pad for DP
+                            tree_search_batch_padded, tree_pad_size = pad_dataproto_to_divisor(
+                                tree_search_batch, self.actor_rollout_wg.world_size
+                            )
+                            tree_output_padded = self.actor_rollout_wg.tree_search_generate(tree_search_batch_padded)
+                            tree_output = unpad_dataproto(tree_output_padded, pad_size=tree_pad_size)
 
-                    if self.config.algorithm.name != "mdpo":
+                        with _timer("dtreerpo_reward_propagation", timing_raw):
+                            dtreerpo_segments, dtreerpo_reward_metrics = self._dtreerpo_compute_rewards_and_segments(
+                                tree_output, batch, gen_batch
+                            )
+                            metrics.update(dtreerpo_reward_metrics)
+
+                        if dtreerpo_segments is not None and len(dtreerpo_segments.batch) > 0:
+                            # Compute old local log probs
+                            with _timer("dtreerpo_old_log_prob", timing_raw):
+                                old_logps_output = self.actor_rollout_wg.compute_dtreerpo_log_prob(dtreerpo_segments)
+                                dtreerpo_segments.batch["old_local_logps"] = old_logps_output.batch["old_local_logps"]
+
+                            # Compute ref log probs if KL is used
+                            if self.config.actor_rollout_ref.actor.use_kl_loss:
+                                with _timer("dtreerpo_ref_log_prob", timing_raw):
+                                    dtreerpo_segments.meta_info["is_lora"] = True
+                                    ref_logps_output = self.actor_rollout_wg.compute_dtreerpo_log_prob(dtreerpo_segments)
+                                    dtreerpo_segments.batch["ref_local_logps"] = ref_logps_output.batch["old_local_logps"]
+                                    dtreerpo_segments.meta_info.pop("is_lora", None)
+
+                            # Actor update
+                            if self.config.trainer.critic_warmup <= self.global_steps:
+                                with _timer("update_actor", timing_raw):
+                                    dtreerpo_segments.meta_info["multi_turn"] = False
+                                    dtreerpo_segments.meta_info["global_step"] = self.global_steps
+                                    # global_token_num needed for MFU calculation in update_actor
+                                    # Must be a list of per-sequence token counts
+                                    attn_mask = dtreerpo_segments.batch["attention_mask"]
+                                    token_counts = attn_mask.sum(dim=-1).long().tolist()
+                                    dtreerpo_segments.meta_info["global_token_num"] = token_counts
+                                    actor_output = self.actor_rollout_wg.update_actor(dtreerpo_segments)
+                                actor_output_metrics = reduce_metrics(actor_output.meta_info["metrics"])
+                                metrics.update(actor_output_metrics)
+
+                            # For downstream metrics, create minimal token_level_scores etc.
+                            if "token_level_scores" not in batch.batch.keys():
+                                n_prompts = batch.batch.batch_size[0]
+                                resp_len = self.config.actor_rollout_ref.rollout.get("response_length", 1)
+                                dummy_scores = torch.zeros(n_prompts, resp_len)
+                                batch.batch["token_level_scores"] = dummy_scores
+                                batch.batch["token_level_rewards"] = dummy_scores
+
+                    else:
+                        raise NotImplementedError(f"Unsupported algorithm: {self.config.algorithm.name}")
+
+                    if self.config.algorithm.name not in ["mdpo", "dtreerpo"]:
                         # Standard flow for non-MDPO algorithms
                         if self.use_reference_policy:
                             # compute reference log_prob
@@ -649,9 +912,9 @@ class DLLMRayPPOTrainer(RayPPOTrainer):
                             actor_output_metrics = reduce_metrics(actor_output.meta_info["metrics"])
                             metrics.update(actor_output_metrics)
 
-                    # Log rollout generations if enabled
+                    # Log rollout generations if enabled (not applicable for dtreerpo)
                     rollout_data_dir = self.config.trainer.get("rollout_data_dir", None)
-                    if rollout_data_dir:
+                    if rollout_data_dir and self.config.algorithm.name != "dtreerpo":
                         with _timer("dump_rollout_generations", timing_raw):
                             print(batch.batch.keys())
                             inputs = self.tokenizer.batch_decode(batch.batch["prompts"], skip_special_tokens=True)
@@ -685,11 +948,15 @@ class DLLMRayPPOTrainer(RayPPOTrainer):
                     }
                 )
                 # collect metrics
-                metrics.update(compute_data_metrics(batch=batch, use_critic=self.use_critic))
-                metrics.update(compute_timing_metrics(batch=batch, timing_raw=timing_raw))
-                # TODO: implement actual tflpo and theoretical tflpo
-                n_gpus = self.resource_pool_manager.get_n_gpus()
-                metrics.update(compute_throughout_metrics(batch=batch, timing_raw=timing_raw, n_gpus=n_gpus))
+                if self.config.algorithm.name != "dtreerpo":
+                    metrics.update(compute_data_metrics(batch=batch, use_critic=self.use_critic))
+                    metrics.update(compute_timing_metrics(batch=batch, timing_raw=timing_raw))
+                    # TODO: implement actual tflpo and theoretical tflpo
+                    n_gpus = self.resource_pool_manager.get_n_gpus()
+                    metrics.update(compute_throughout_metrics(batch=batch, timing_raw=timing_raw, n_gpus=n_gpus))
+                else:
+                    # dtreerpo batch doesn't have standard responses/attention_mask/global_token_num
+                    metrics.update({f"timing_s/{name}": value for name, value in timing_raw.items()})
 
                 # TODO: make a canonical logger that supports various backend
                 logger.log(data=metrics, step=self.global_steps)

--- a/verl/trainer/ppo/dllm_ray_trainer.py
+++ b/verl/trainer/ppo/dllm_ray_trainer.py
@@ -188,9 +188,7 @@ class DLLMRayPPOTrainer(RayPPOTrainer):
 
                 with _timer("step", timing_raw):
                     # d-TreeRPO skips standard rollout; tree search handles generation
-                    if self.config.algorithm.name == "dtreerpo":
-                        gen_batch_output = None
-                    else:
+                    if self.config.algorithm.name != "dtreerpo":
                         # generate a batch
                         with _timer("gen", timing_raw):
                             if not self.async_rollout_mode:
@@ -200,7 +198,6 @@ class DLLMRayPPOTrainer(RayPPOTrainer):
                                 gen_batch_output = self.async_rollout_manager.generate_sequences(gen_batch)
                                 self.async_rollout_manager.sleep()
 
-                    if self.config.algorithm.name != "dtreerpo":
                         if self.config.algorithm.adv_estimator == AdvantageEstimator.REMAX:
                             with _timer("gen_max", timing_raw):
                                 gen_baseline_batch = deepcopy(gen_batch)

--- a/verl/trainer/ppo/dtreerpo_algos.py
+++ b/verl/trainer/ppo/dtreerpo_algos.py
@@ -1,0 +1,231 @@
+# Copyright 2025 Shanghai AI Lab
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+d-TreeRPO (Diffusion Tree Reward Propagation Optimization) algorithm functions.
+
+Core algorithm logic for computing rewards at leaf nodes, propagating values
+through the tree, computing local advantages, and constructing training segments.
+"""
+
+import numpy as np
+import torch
+from tensordict import TensorDict
+
+from verl import DataProto
+from verl.trainer.ppo.ray_trainer import compute_reward
+
+
+def compute_dtreerpo_rewards_and_segments(
+    tree_output,
+    batch,
+    reward_fn,
+    response_length_cfg,
+    micro_batch_size,
+    temperature,
+):
+    """
+    Given tree search output, compute rewards at leaf nodes, propagate upward,
+    compute local advantages, and construct training segments.
+
+    Args:
+        tree_output (DataProto): Output from tree search generation containing tree structure.
+        batch (DataProto): Original batch with non_tensor_batch for reward computation.
+        reward_fn: Reward function for computing leaf rewards.
+        response_length_cfg (int): Configured response length for dummy fields.
+        micro_batch_size (int): Micro batch size for log prob computation.
+        temperature (float): Temperature for log prob computation.
+
+    Returns:
+        Tuple of (segments DataProto or None, metrics dict).
+    """
+    tree_batch = tree_output.batch
+    meta = tree_output.meta_info
+    prompt_length = meta["prompt_length"]
+    num_leaves = meta["num_leaves"]
+    num_nodes = meta["num_nodes"]
+    branch_points = meta["branch_points"]
+
+    # After DP concat, dim0 = total_batch_size.
+    # Tensors: (total_batch, num_nodes/num_leaves, ...)
+    # Tree structure is the same for all batch items; take from first item.
+    batch_size = tree_batch["node_generations"].size(0)  # total batch size after DP gather
+
+    node_generations = tree_batch["node_generations"]  # (B, num_nodes, seq_len)
+    node_steps = tree_batch["node_steps"][0]           # (num_nodes,) - same for all batch items
+    node_is_leaf = tree_batch["node_is_leaf"][0]       # (num_nodes,)
+    node_parent_idx = tree_batch["node_parent_idx"][0] # (num_nodes,)
+    node_children_idx = tree_batch["node_children_idx"][0]  # (num_nodes, max_children)
+
+    leaf_input_ids_bt = tree_batch["leaf_input_ids"]   # (B, num_leaves, seq_len)
+    leaf_responses_bt = tree_batch["leaf_responses"]   # (B, num_leaves, resp_len)
+    leaf_attn_bt = tree_batch["leaf_attn"]             # (B, num_leaves, seq_len)
+
+    # Transpose node_generations to (num_nodes, B, seq_len) for tree processing
+    node_generations = node_generations.permute(1, 0, 2).contiguous()  # (num_nodes, B, seq_len)
+
+    seq_len = node_generations.size(-1)
+    response_length = seq_len - prompt_length
+    device = node_generations.device
+
+    # Flatten leaf data to (num_leaves * B, ...) for reward computation
+    leaf_input_ids = leaf_input_ids_bt.permute(1, 0, 2).contiguous().reshape(-1, seq_len)  # (num_leaves * B, seq_len)
+    leaf_responses = leaf_responses_bt.permute(1, 0, 2).contiguous().reshape(-1, response_length)
+    leaf_attn = leaf_attn_bt.permute(1, 0, 2).contiguous().reshape(-1, seq_len)
+
+    # Compute rewards for leaf nodes
+    leaf_total = num_leaves * batch_size
+    # Expand non_tensor_batch to match leaf batch size before passing to DataProto
+    expanded_non_tensors = {}
+    if batch.non_tensor_batch is not None:
+        for key, val in batch.non_tensor_batch.items():
+            if isinstance(val, np.ndarray):
+                # Repeat each element num_leaves times (leaves are ordered leaf-major)
+                expanded_non_tensors[key] = np.tile(val, num_leaves)[:leaf_total]
+            else:
+                expanded_non_tensors[key] = val
+
+    leaf_batch = DataProto.from_dict(
+        tensors={
+            "input_ids": leaf_input_ids,
+            "responses": leaf_responses,
+            "prompts": leaf_input_ids[:, :prompt_length],
+            "attention_mask": leaf_attn,
+            "position_ids": leaf_attn.cumsum(dim=-1) - 1,
+        },
+        non_tensors=expanded_non_tensors,
+    )
+
+    reward_tensor, reward_extra_infos_dict = compute_reward(leaf_batch, reward_fn)
+    leaf_rewards = reward_tensor.sum(dim=-1)  # (num_leaves * batch_size,)
+
+    # Assign rewards to leaf nodes: reshape to (num_leaves, batch_size)
+    leaf_rewards_mat = leaf_rewards.reshape(num_leaves, batch_size)
+
+    # Create value vectors for all nodes
+    node_value_vecs = torch.zeros(num_nodes, batch_size, device=device)
+
+    # Assign leaf values
+    leaf_idx = 0
+    for i in range(num_nodes):
+        if node_is_leaf[i]:
+            node_value_vecs[i] = leaf_rewards_mat[leaf_idx]
+            leaf_idx += 1
+
+    # Bottom-up propagation: process steps from lowest to highest
+    for step in sorted(branch_points[:-1]):
+        for i in range(num_nodes):
+            if node_steps[i] == step and i > 0:  # skip root (i=0)
+                children = node_children_idx[i]
+                valid_children = children[children >= 0]
+                if len(valid_children) > 0:
+                    child_vals = torch.stack([node_value_vecs[c] for c in valid_children])
+                    node_value_vecs[i] = torch.nanmean(child_vals, dim=0)
+
+    # Root propagation
+    root_children = node_children_idx[0]
+    valid_root_children = root_children[root_children >= 0]
+    if len(valid_root_children) > 0:
+        root_child_vals = torch.stack([node_value_vecs[c] for c in valid_root_children])
+        node_value_vecs[0] = torch.nanmean(root_child_vals, dim=0)
+
+    # Compute local advantages for each non-root node
+    node_local_adv = torch.zeros(num_nodes, batch_size, device=device)
+    for i in range(1, num_nodes):
+        parent = node_parent_idx[i].item()
+        siblings = node_children_idx[parent]
+        valid_siblings = siblings[(siblings >= 0) & (siblings != i)]
+        if len(valid_siblings) > 0:
+            sib_vals = torch.stack([node_value_vecs[s] for s in valid_siblings])
+            sib_mean = torch.nanmean(sib_vals, dim=0)
+        else:
+            sib_mean = torch.zeros(batch_size, device=device)
+        node_local_adv[i] = node_value_vecs[i] - sib_mean
+
+    # Build training segments
+    all_parent_ids = []
+    all_child_ids = []
+    all_attention_masks = []
+    all_local_advantages = []
+    all_group_ids = []
+
+    group_key_to_id = {}
+    next_gid = 0
+
+    for i in range(1, num_nodes):
+        parent_idx_val = node_parent_idx[i].item()
+        parent_gen = node_generations[parent_idx_val]   # (batch_size, seq_len)
+        child_gen = node_generations[i]                 # (batch_size, seq_len)
+        adv = node_local_adv[i]                         # (batch_size,)
+
+        # Build attention mask
+        attn = torch.ones(batch_size, seq_len, dtype=torch.long, device=device)
+
+        for b in range(batch_size):
+            key = (parent_idx_val, b)
+            gid = group_key_to_id.get(key)
+            if gid is None:
+                gid = next_gid
+                next_gid += 1
+                group_key_to_id[key] = gid
+            all_group_ids.append(gid)
+
+        all_parent_ids.append(parent_gen)
+        all_child_ids.append(child_gen)
+        all_attention_masks.append(attn)
+        all_local_advantages.append(adv)
+
+    if not all_parent_ids:
+        return None, {"dtreerpo/mean_leaf_reward": 0.0}
+
+    parent_ids_cat = torch.cat(all_parent_ids, dim=0)
+    child_ids_cat = torch.cat(all_child_ids, dim=0)
+    attn_cat = torch.cat(all_attention_masks, dim=0)
+    adv_cat = torch.cat(all_local_advantages, dim=0)
+    group_ids_cat = torch.tensor(all_group_ids, dtype=torch.long, device=device)
+    prompt_length_t = torch.tensor([prompt_length], dtype=torch.long, device=device).expand(parent_ids_cat.size(0))
+
+    segments = DataProto.from_dict(
+        tensors={
+            "parent_ids": parent_ids_cat,
+            "child_ids": child_ids_cat,
+            "attention_mask": attn_cat,
+            "local_advantages": adv_cat,
+            "group_ids": group_ids_cat,
+            "prompt_length": prompt_length_t,
+            # Dummy fields for metrics compatibility
+            "prompts": parent_ids_cat[:, :prompt_length],
+            "responses": child_ids_cat[:, prompt_length:],
+            "token_level_scores": torch.zeros(parent_ids_cat.size(0), response_length_cfg, device=device),
+            "token_level_rewards": torch.zeros(parent_ids_cat.size(0), response_length_cfg, device=device),
+            "response_mask": attn_cat[:, -response_length_cfg:],
+        },
+    )
+    segments.meta_info["micro_batch_size"] = micro_batch_size
+    segments.meta_info["temperature"] = temperature
+
+    dtreerpo_metrics = {
+        "dtreerpo/mean_leaf_reward": leaf_rewards.mean().item(),
+        "dtreerpo/mean_root_value": node_value_vecs[0].mean().item(),
+        "dtreerpo/mean_local_adv": adv_cat.mean().item(),
+        "dtreerpo/num_segments": parent_ids_cat.size(0),
+    }
+
+    # Also set reward tensors on batch for standard metrics
+    # Use leaf rewards averaged per prompt as the reward signal
+    mean_leaf_reward_per_prompt = leaf_rewards_mat.mean(dim=0)  # (batch_size,)
+    if reward_extra_infos_dict:
+        batch.non_tensor_batch.update({k: np.array(v) for k, v in reward_extra_infos_dict.items()})
+
+    return segments, dtreerpo_metrics

--- a/verl/utils/checkpoint/fsdp_checkpoint_manager.py
+++ b/verl/utils/checkpoint/fsdp_checkpoint_manager.py
@@ -195,7 +195,13 @@ class FSDPCheckpointManager(BaseCheckpointManager):
                 # Some model's name_or_path is empty if not initialized from pretrained,
                 # in this cases, we don't save generation config.
                 generation_config = GenerationConfig.from_pretrained(model_config.name_or_path)
-                generation_config.save_pretrained(local_path)
+                # Fix invalid generation config (e.g., temperature=0.0 with do_sample=False)
+                if not generation_config.do_sample and generation_config.temperature == 0.0:
+                    generation_config.temperature = 1.0
+                try:
+                    generation_config.save_pretrained(local_path)
+                except ValueError:
+                    pass  # Skip saving generation config if validation fails
             else:
                 generation_config = None
 

--- a/verl/workers/actor/dream_dp_actor_dtreerpo.py
+++ b/verl/workers/actor/dream_dp_actor_dtreerpo.py
@@ -1,0 +1,61 @@
+# Copyright 2025 Shanghai AI Lab
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+d-TreeRPO Actor for Dream (Masked Diffusion LM with shifted logits).
+Inherits from the LLaDA d-TreeRPO actor and overrides _get_logits for Dream's shift behavior.
+"""
+
+import logging
+import os
+
+import torch
+from torch import nn
+
+from verl.workers.actor import DataParallelPPOActor
+from verl.workers.actor.llada_dp_actor_dtreerpo import DLLMDataParallelPPOActor as BaseDataParallelPPOActor
+from verl.utils.device import is_cuda_available, is_npu_available
+
+if is_cuda_available:
+    from flash_attn.bert_padding import index_first_axis, pad_input, rearrange, unpad_input
+elif is_npu_available:
+    from transformers.integrations.npu_flash_attention import index_first_axis, pad_input, rearrange, unpad_input
+
+
+__all__ = ["DataParallelPPOActor", "BaseDataParallelPPOActor"]
+
+logger = logging.getLogger(__file__)
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
+
+
+class DLLMDataParallelPPOActor(BaseDataParallelPPOActor):
+    def _get_logits(self, model, packed_input, cu_seqlens, max_seqlen, prompt_len, cfg_scale=0.0, MASK_TOKEN_ID=126336):
+        """
+        Dream model requires logits shift: shift_logits = cat([logits[:, 0:1], logits[:, :-1]], dim=1)
+        """
+        if cfg_scale > 0.:
+            un_packed_input = packed_input.clone()
+            for i in range(len(cu_seqlens) - 1):
+                start = cu_seqlens[i].item()
+                un_packed_input[0, start:start + prompt_len[i].item()] = MASK_TOKEN_ID
+            packed_input_cat = torch.cat([packed_input, un_packed_input], dim=0)
+            cu_seqlens_cat = torch.cat([cu_seqlens, cu_seqlens[1:] + cu_seqlens[-1]], dim=0)
+            logits = model(packed_input_cat, cu_seqlens=cu_seqlens_cat, max_seqlen=max_seqlen).logits
+            logits, un_logits = torch.chunk(logits, 2, dim=0)
+            logits = un_logits + (cfg_scale + 1) * (logits - un_logits)
+        else:
+            logits = model(packed_input, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen).logits
+        logits = logits[:, :packed_input.shape[1]]
+        # Dream requires shifted logits
+        shift_logits = torch.cat([logits[:, 0:1], logits[:, :-1]], dim=1).contiguous()
+        return shift_logits

--- a/verl/workers/actor/llada_dp_actor_dtreerpo.py
+++ b/verl/workers/actor/llada_dp_actor_dtreerpo.py
@@ -1,0 +1,443 @@
+# Copyright 2025 Shanghai AI Lab
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+d-TreeRPO Actor for LLaDA (Masked Diffusion LM).
+Implements local transition log-prob computation and PPO + self-distillation loss.
+"""
+
+import itertools
+import logging
+import math
+import os
+from typing import Tuple
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+import verl.utils.torch_functional as verl_F
+from verl import DataProto
+from verl.trainer.ppo.dllm_core_algos import agg_loss
+from verl.utils.debug import GPUMemoryLogger
+from verl.utils.device import get_device_name, get_torch_device, is_cuda_available, is_npu_available
+from verl.utils.fsdp_utils import FSDPModule, fsdp2_clip_grad_norm_
+from verl.utils.py_functional import append_to_dict
+from verl.utils.seqlen_balancing import get_reverse_idx, rearrange_micro_batches
+from verl.workers.actor import DataParallelPPOActor
+
+if is_cuda_available:
+    from flash_attn.bert_padding import index_first_axis, pad_input, rearrange, unpad_input
+elif is_npu_available:
+    from transformers.integrations.npu_flash_attention import index_first_axis, pad_input, rearrange, unpad_input
+
+
+__all__ = ["DataParallelPPOActor"]
+
+logger = logging.getLogger(__file__)
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
+
+
+class DLLMDataParallelPPOActor(DataParallelPPOActor):
+    def __init__(self, config, actor_module: nn.Module, actor_optimizer: torch.optim.Optimizer = None):
+        """When optimizer is None, it is Reference Policy"""
+        super().__init__(config, actor_module, actor_optimizer)
+
+        self.MASK_TOKEN_ID = actor_module.config.mask_token_id
+        self.PAD_TOKEN_ID = actor_module.config.pad_token_id
+
+    def _get_logits(self, model, packed_input, cu_seqlens, max_seqlen, prompt_len, cfg_scale=0.0, MASK_TOKEN_ID=126336):
+        """
+        Get logits from model using packed input format.
+        packed_input: (1, total_seqlen)
+        cu_seqlens: (batch_size+1,)
+        max_seqlen: int
+        prompt_len: (batch_size,) True prompt length of each sample
+        """
+        if cfg_scale > 0.:
+            un_packed_input = packed_input.clone()
+            for i in range(len(cu_seqlens) - 1):
+                start = cu_seqlens[i].item()
+                un_packed_input[0, start:start + prompt_len[i].item()] = MASK_TOKEN_ID
+            packed_input_cat = torch.cat([packed_input, un_packed_input], dim=0)
+            cu_seqlens_cat = torch.cat([cu_seqlens, cu_seqlens[1:] + cu_seqlens[-1]], dim=0)
+            logits = model(packed_input_cat, cu_seqlens=cu_seqlens_cat, max_seqlen=max_seqlen).logits
+            logits, un_logits = torch.chunk(logits, 2, dim=0)
+            logits = un_logits + (cfg_scale + 1) * (logits - un_logits)
+        else:
+            logits = model(packed_input, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen).logits
+        return logits[:, :packed_input.shape[1]]
+
+    def _get_local_transition_logps(self, model, parent_ids, child_ids, attention_mask, prompt_length, cfg_scale=0.0):
+        """
+        Compute local transition log-probs: only at positions where parent is MASK and child is not MASK.
+        Returns per-token log probs of shape (batch_size, completion_length).
+        """
+        batch_size, seq_len = parent_ids.size()
+        device = parent_ids.device
+        completion_length = seq_len - prompt_length
+
+        # Pack sequences for efficient model forward
+        packed_input = []
+        cu_seqlens = [0]
+        max_seqlen = 0
+        prompt_lens = []
+        for b in range(batch_size):
+            valid_tokens = parent_ids[b][attention_mask[b] == 1]
+            packed_input.append(valid_tokens)
+            cu_seqlens.append(cu_seqlens[-1] + len(valid_tokens))
+            max_seqlen = max(max_seqlen, len(valid_tokens))
+            prompt_lens.append(attention_mask[b, :prompt_length].sum())
+        packed_input = torch.cat(packed_input, dim=0).unsqueeze(0)
+        cu_seqlens = torch.tensor(cu_seqlens, dtype=torch.int32, device=device)
+        prompt_lens = torch.stack(prompt_lens)
+
+        logits = self._get_logits(
+            model=model, packed_input=packed_input, cu_seqlens=cu_seqlens,
+            max_seqlen=max_seqlen, prompt_len=prompt_lens,
+            cfg_scale=cfg_scale, MASK_TOKEN_ID=self.MASK_TOKEN_ID
+        )
+
+        # Restore logits to padded shape
+        all_logps = torch.zeros(batch_size, completion_length, device=device, dtype=torch.float32)
+        for b in range(batch_size):
+            start, end = cu_seqlens[b], cu_seqlens[b + 1]
+            logits_b = torch.zeros(seq_len, logits.size(-1), device=device, dtype=logits.dtype)
+            logits_b[attention_mask[b] == 1] = logits[0, start:end]
+
+            comp_logits = logits_b[prompt_length:]  # (completion_length, V)
+            comp_child = child_ids[b, prompt_length:]
+            comp_parent = parent_ids[b, prompt_length:]
+
+            # Changed mask: parent is MASK, child is not MASK
+            changed = (comp_parent == self.MASK_TOKEN_ID) & (comp_child != self.MASK_TOKEN_ID)
+
+            loss_flat = F.cross_entropy(
+                comp_logits, comp_child, reduction="none"
+            )
+            per_token_logps = -loss_flat  # (completion_length,)
+            all_logps[b] = per_token_logps * changed.float()
+
+        all_logps = torch.nan_to_num(all_logps, nan=0.0, posinf=0.0, neginf=0.0)
+        return all_logps
+
+    def _build_completion_mask(self, completion_ids):
+        """Build mask: 1 for unmasked tokens up to (and including) first EOS, 0 elsewhere."""
+        device = completion_ids.device
+        is_unmasked = (completion_ids != self.MASK_TOKEN_ID).float()
+
+        eos_id = self.PAD_TOKEN_ID  # LLaDA uses pad_token_id as EOS boundary
+        is_eos = (completion_ids == eos_id)
+        B, L = is_eos.size()
+        eos_idx = torch.full((B,), L, dtype=torch.long, device=device)
+        has_eos = is_eos.any(dim=1)
+        eos_idx[has_eos] = is_eos[has_eos].int().argmax(dim=1)
+
+        seq_idx = torch.arange(L, device=device).unsqueeze(0).expand(B, L)
+        eos_pos_mask = (seq_idx <= eos_idx.unsqueeze(1)).float()
+
+        return is_unmasked * eos_pos_mask
+
+    def _forward_micro_batch_logps(self, micro_batch, cfg_scale=0.0):
+        """Compute local transition log probs for a micro batch."""
+        parent_ids = micro_batch["parent_ids"]
+        child_ids = micro_batch["child_ids"]
+        attention_mask = micro_batch["attention_mask"]
+        prompt_length = micro_batch["prompt_length"]
+
+        if isinstance(prompt_length, torch.Tensor):
+            prompt_length = prompt_length.item()
+
+        with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+            local_logps = self._get_local_transition_logps(
+                model=self.actor_module,
+                parent_ids=parent_ids,
+                child_ids=child_ids,
+                attention_mask=attention_mask,
+                prompt_length=prompt_length,
+                cfg_scale=cfg_scale,
+            )
+        return local_logps
+
+    @GPUMemoryLogger(role="dp actor", logger=logger)
+    def compute_log_prob(self, data: DataProto, calculate_entropy=False) -> torch.Tensor:
+        """Compute old local transition log probs for d-TreeRPO segments."""
+        self.actor_module.eval()
+
+        micro_batch_size = data.meta_info["micro_batch_size"]
+        cfg_scale = data.meta_info.get("cfg_scale", 0.0)
+
+        select_keys = ["parent_ids", "child_ids", "attention_mask", "prompt_length"]
+        batch = data.select(batch_keys=select_keys).batch
+        micro_batches = batch.split(micro_batch_size)
+
+        logps_lst = []
+        for micro_batch in micro_batches:
+            with torch.no_grad():
+                local_logps = self._forward_micro_batch_logps(micro_batch, cfg_scale=cfg_scale)
+            logps_lst.append(local_logps)
+
+        all_logps = torch.concat(logps_lst, dim=0)
+        return None, all_logps, None  # (entropy, log_probs, loss_per_sample)
+
+    @GPUMemoryLogger(role="dp actor", logger=logger)
+    def update_policy(self, data: DataProto):
+        """Update policy using PPO loss on local transitions + optional self-distillation."""
+        self.actor_module.train()
+
+        select_keys = [
+            "parent_ids", "child_ids", "attention_mask", "prompt_length",
+            "old_local_logps", "local_advantages", "group_ids",
+        ]
+        if self.config.use_kl_loss:
+            select_keys.append("ref_local_logps")
+        batch = data.select(batch_keys=select_keys).batch
+
+        # d-TreeRPO config
+        epsilon = self.config.get("clip_ratio", 0.2)
+        kl_coef = self.config.get("kl_loss_coef", 0.0)
+        enable_self_distillation = self.config.get("enable_self_distillation", False)
+        sd_lambda_max = self.config.get("sd_lambda_max", 3e-3)
+        sd_gamma = self.config.get("sd_gamma", 2.0)
+        sd_tau_max = self.config.get("sd_tau_max", 2.0)
+        sd_beta = self.config.get("sd_beta", 0.7)
+        max_steps = self.config.get("max_steps", 30000)
+        global_step = data.meta_info.get("global_step", 0)
+
+        cfg_scale = data.meta_info.get("cfg_scale", 0.0)
+
+        dataloader = batch.split(self.config.ppo_mini_batch_size)
+
+        metrics = {}
+        for epoch in range(self.config.ppo_epochs):
+            for batch_idx, mini_batch in enumerate(dataloader):
+                if self.config.use_dynamic_bsz:
+                    max_token_len = self.config.ppo_max_token_len_per_gpu * getattr(self, 'ulysses_sequence_parallel_size', 1)
+                    micro_batches, _ = rearrange_micro_batches(batch=mini_batch, max_token_len=max_token_len)
+                else:
+                    self.gradient_accumulation = self.config.ppo_mini_batch_size // self.config.ppo_micro_batch_size_per_gpu
+                    micro_batches = mini_batch.split(self.config.ppo_micro_batch_size_per_gpu)
+
+                self.actor_optimizer.zero_grad()
+
+                for micro_data in micro_batches:
+                    micro_data = micro_data.to(get_torch_device().current_device())
+
+                    parent_ids = micro_data["parent_ids"]
+                    child_ids = micro_data["child_ids"]
+                    attention_mask = micro_data["attention_mask"]
+                    prompt_length = micro_data["prompt_length"]
+                    if isinstance(prompt_length, torch.Tensor):
+                        prompt_length = prompt_length[0].item()
+
+                    old_local_logps = micro_data["old_local_logps"]
+                    local_advantages = micro_data["local_advantages"]
+                    group_ids = micro_data.get("group_ids", None)
+
+                    # Compute new local transition log probs
+                    new_local_logps = self._get_local_transition_logps(
+                        model=self.actor_module,
+                        parent_ids=parent_ids,
+                        child_ids=child_ids,
+                        attention_mask=attention_mask,
+                        prompt_length=prompt_length,
+                        cfg_scale=cfg_scale,
+                    )
+
+                    # Build active mask
+                    child_completion = child_ids[:, prompt_length:]
+                    completion_mask = self._build_completion_mask(child_completion)
+                    changed_mask = (new_local_logps != 0).float()
+                    active_mask = completion_mask * changed_mask
+                    L_eff = active_mask.sum(dim=1).clamp_min(1)
+
+                    # PPO loss
+                    ratio = torch.exp(new_local_logps - old_local_logps)
+                    clipped_ratio = torch.clamp(ratio, 1.0 - epsilon, 1.0 + epsilon)
+                    A = local_advantages.unsqueeze(1)  # (B, 1)
+
+                    ppo_obj = torch.min(ratio * A, clipped_ratio * A)
+                    ppo_obj_masked = ppo_obj * active_mask
+                    policy_loss = -(ppo_obj_masked.sum(dim=1) / L_eff).mean()
+
+                    total_loss = policy_loss
+
+                    # KL penalty
+                    if self.config.use_kl_loss and "ref_local_logps" in micro_data.keys():
+                        ref_local_logps = micro_data["ref_local_logps"]
+                        delta = ref_local_logps - new_local_logps
+                        per_token_kl = torch.exp(delta) - delta - 1.0
+                        kl_per_sample = (per_token_kl * active_mask).sum(dim=1) / L_eff
+                        kl_loss = kl_coef * kl_per_sample.mean()
+                        total_loss = total_loss + kl_loss
+                        metrics["actor/kl_loss"] = kl_loss.detach().item()
+
+                    # Self-distillation loss
+                    sd_loss = torch.tensor(0.0, device=total_loss.device)
+                    if enable_self_distillation and group_ids is not None:
+                        sd_loss = self._compute_self_distillation_loss(
+                            model=self.actor_module,
+                            parent_ids=parent_ids,
+                            child_ids=child_ids,
+                            attention_mask=attention_mask,
+                            prompt_length=prompt_length,
+                            group_ids=group_ids,
+                            local_advantages=local_advantages,
+                            active_mask=active_mask,
+                            global_step=global_step,
+                            max_steps=max_steps,
+                            lambda_max=sd_lambda_max,
+                            gamma=sd_gamma,
+                            tau_max=sd_tau_max,
+                            beta=sd_beta,
+                            cfg_scale=cfg_scale,
+                        )
+                        total_loss = total_loss + sd_loss
+
+                    if self.config.use_dynamic_bsz:
+                        loss = total_loss * (len(micro_data) / self.config.ppo_mini_batch_size)
+                    else:
+                        loss = total_loss / self.gradient_accumulation
+                    loss.backward()
+
+                    # Metrics
+                    with torch.no_grad():
+                        clip_hi = verl_F.masked_mean((ratio > (1.0 + epsilon)).float(), active_mask)
+                        clip_lo = verl_F.masked_mean((ratio < (1.0 - epsilon)).float(), active_mask)
+                    data_metrics = {
+                        "actor/pg_loss": policy_loss.detach().item(),
+                        "actor/pg_clipfrac_hi": clip_hi.detach().item(),
+                        "actor/pg_clipfrac_lo": clip_lo.detach().item(),
+                        "actor/sd_loss": sd_loss.detach().item(),
+                    }
+                    append_to_dict(metrics, data_metrics)
+
+                grad_norm = self._optimizer_step()
+                append_to_dict(metrics, {"actor/grad_norm": grad_norm.detach().item()})
+
+        self.actor_optimizer.zero_grad()
+        return metrics
+
+    def _compute_self_distillation_loss(
+        self, model, parent_ids, child_ids, attention_mask, prompt_length,
+        group_ids, local_advantages, active_mask,
+        global_step, max_steps, lambda_max, gamma, tau_max, beta, cfg_scale,
+    ):
+        """Time-scheduled self-distillation loss that encourages consistency among siblings."""
+        device = parent_ids.device
+
+        progress = min(1.0, max(0.0, global_step / max(1, max_steps)))
+        lambda_t = lambda_max * (math.exp(gamma * progress) - 1.0) / (math.exp(gamma) - 1.0)
+        tau_t = max(tau_max * max(0.0, (1.0 - progress)) ** beta, 1e-6)
+
+        group_ids = group_ids.long()
+        uniq_groups = torch.unique(group_ids)
+        child_completion = child_ids[:, prompt_length:]
+        B_all, Lc = child_completion.size()
+
+        # Find one representative parent per group
+        ref_indices = []
+        group_to_pos = {}
+        for pos, g in enumerate(uniq_groups.tolist()):
+            idxs = (group_ids == g).nonzero(as_tuple=False).squeeze(-1)
+            if idxs.numel() == 0:
+                continue
+            ref_indices.append(idxs[0])
+            group_to_pos[g] = pos
+
+        if len(ref_indices) == 0:
+            return torch.tensor(0.0, device=device)
+
+        ref_indices = torch.stack(ref_indices, dim=0)
+
+        # Compute parent logits for reference samples
+        ref_parent = parent_ids[ref_indices]
+        ref_attn = attention_mask[ref_indices]
+        batch_size_ref = ref_parent.size(0)
+        seq_len = ref_parent.size(1)
+
+        packed_input = []
+        cu_seqlens = [0]
+        max_seqlen = 0
+        prompt_lens = []
+        for b in range(batch_size_ref):
+            valid = ref_parent[b][ref_attn[b] == 1]
+            packed_input.append(valid)
+            cu_seqlens.append(cu_seqlens[-1] + len(valid))
+            max_seqlen = max(max_seqlen, len(valid))
+            prompt_lens.append(ref_attn[b, :prompt_length].sum())
+        packed_input = torch.cat(packed_input, dim=0).unsqueeze(0)
+        cu_seqlens_t = torch.tensor(cu_seqlens, dtype=torch.int32, device=device)
+        prompt_lens_t = torch.stack(prompt_lens)
+
+        with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+            raw_logits = self._get_logits(
+                model=model, packed_input=packed_input, cu_seqlens=cu_seqlens_t,
+                max_seqlen=max_seqlen, prompt_len=prompt_lens_t,
+                cfg_scale=cfg_scale, MASK_TOKEN_ID=self.MASK_TOKEN_ID,
+            )
+
+        # Restore to padded per-sample logits for completion region
+        logp_parent_slice = torch.zeros(batch_size_ref, Lc, raw_logits.size(-1), device=device, dtype=torch.float32)
+        for b in range(batch_size_ref):
+            start, end = cu_seqlens[b], cu_seqlens[b + 1]
+            full_logits = torch.zeros(seq_len, raw_logits.size(-1), device=device, dtype=raw_logits.dtype)
+            full_logits[ref_attn[b] == 1] = raw_logits[0, start:end]
+            logp_parent_slice[b] = F.log_softmax(full_logits[prompt_length:prompt_length + Lc].float(), dim=-1)
+
+        eps = 1e-8
+        consistency_sum = torch.tensor(0.0, device=device)
+        consistency_count = 0
+
+        for g in uniq_groups.tolist():
+            idxs = (group_ids == g).nonzero(as_tuple=False).squeeze(-1)
+            if idxs.numel() <= 1:
+                continue
+
+            A_full = local_advantages[idxs].detach()
+            A_full = torch.nan_to_num(A_full, nan=0.0, posinf=0.0, neginf=0.0)
+            pos_mask = (A_full > 0)
+            if pos_mask.sum().item() == 0:
+                continue
+
+            A = A_full[pos_mask]
+            idxs_pos = idxs[pos_mask]
+            w = F.softmax(A / tau_t, dim=0)
+
+            group_active = active_mask[idxs_pos] > 0
+            toks_group = child_completion[idxs_pos]
+            ref_pos = group_to_pos[g]
+
+            for j in range(Lc):
+                active_k = group_active[:, j]
+                if not active_k.any():
+                    continue
+                toks_j = toks_group[active_k, j]
+                w_j = w[active_k]
+
+                unique_tokens, inv = torch.unique(toks_j, return_inverse=True)
+                q_weights = torch.zeros_like(unique_tokens, dtype=torch.float32)
+                q_weights.index_add_(0, inv, w_j.to(q_weights.dtype))
+                ws_sum = q_weights.sum()
+                if ws_sum <= 0:
+                    continue
+                q_probs = q_weights / (ws_sum + eps)
+
+                logp_support = logp_parent_slice[ref_pos, j].gather(0, unique_tokens)
+                kl_j = torch.sum(q_probs * (torch.log(q_probs + eps) - logp_support))
+                consistency_sum = consistency_sum + kl_j
+                consistency_count += 1
+
+        if consistency_count > 0:
+            return lambda_t * (consistency_sum / float(consistency_count))
+        return torch.tensor(0.0, device=device)

--- a/verl/workers/dllm_fsdp_workers.py
+++ b/verl/workers/dllm_fsdp_workers.py
@@ -349,6 +349,14 @@ class DLLMActorRolloutRefWorker(ActorRolloutRefWorker):
                     from verl.workers.sharding_manager.base import BaseShardingManager
                     rollout = MDPORollout(module=self.actor_module_fsdp, config=self.config.rollout, tokenizer=self.tokenizer)
                     rollout_sharding_manager = BaseShardingManager()
+                elif self.config.algorithm.name == "dtreerpo":
+                    from verl.workers.rollout.dtreerpo_llada_rollout import DTreeRPORollout
+                    from verl.workers.sharding_manager.base import BaseShardingManager
+                    from omegaconf import OmegaConf
+                    rollout_config = OmegaConf.to_container(self.config.rollout, resolve=True)
+                    rollout_config["model_name"] = self.config.model.name
+                    rollout = DTreeRPORollout(module=self.actor_module_fsdp, config=rollout_config, tokenizer=self.tokenizer)
+                    rollout_sharding_manager = BaseShardingManager()
                 elif not use_cache:
                     if self.config.algorithm.name == "cj-grpo":
                         from verl.workers.rollout.cj_llada_rollout import DLLMRollout
@@ -382,6 +390,14 @@ class DLLMActorRolloutRefWorker(ActorRolloutRefWorker):
                     from verl.workers.rollout.mdpo_dream_rollout import MDPORollout
                     from verl.workers.sharding_manager.base import BaseShardingManager
                     rollout = MDPORollout(module=self.actor_module_fsdp, config=self.config.rollout, tokenizer=self.tokenizer)
+                    rollout_sharding_manager = BaseShardingManager()
+                elif self.config.algorithm.name == "dtreerpo":
+                    from verl.workers.rollout.dtreerpo_llada_rollout import DTreeRPORollout
+                    from verl.workers.sharding_manager.base import BaseShardingManager
+                    from omegaconf import OmegaConf
+                    rollout_config = OmegaConf.to_container(self.config.rollout, resolve=True)
+                    rollout_config["model_name"] = self.config.model.name
+                    rollout = DTreeRPORollout(module=self.actor_module_fsdp, config=rollout_config, tokenizer=self.tokenizer)
                     rollout_sharding_manager = BaseShardingManager()
                 elif not use_cache:
                     if self.config.algorithm.name == "cj-grpo":
@@ -930,304 +946,6 @@ class DLLMActorRolloutRefWorker(ActorRolloutRefWorker):
         )
         
         return DataProto(batch=batch)
-
-    @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)
-    def tree_search_generate(self, prompts: DataProto):
-        """
-        d-TreeRPO tree search: build a tree of partial generations with branching at predefined diffusion steps.
-        Returns all node data for reward computation and training segment construction.
-        """
-        from verl.workers.rollout.generate import add_gumbel_noise, get_num_transfer_tokens
-        import torch.nn.functional as F
-
-        batch = prompts.batch
-        input_ids = batch["input_ids"]  # (batch_size, prompt_len)
-        attention_mask = batch["attention_mask"]
-        batch_size = input_ids.size(0)
-        prompt_length = input_ids.size(1)
-        # Ensure tensors are on GPU (Ray may pass CPU tensors)
-        device = next(self.actor_module_fsdp.parameters()).device
-        input_ids = input_ids.to(device)
-        attention_mask = attention_mask.to(device)
-
-        # Tree search config from meta_info
-        response_length = prompts.meta_info.get("response_length", self.config.rollout.get("response_length"))
-        num_diffusion_steps = prompts.meta_info.get("num_diffusion_steps", self.config.rollout.get("num_diffusion_steps"))
-        block_length = prompts.meta_info.get("block_length", self.config.rollout.get("block_length"))
-        tree_branch_factor = prompts.meta_info.get("tree_branch_factor", 4)
-        tree_contraction_factor = prompts.meta_info.get("tree_contraction_factor", 2)
-        num_tree_samples = prompts.meta_info.get("num_tree_samples", 4)
-        temperature = prompts.meta_info.get("temperature", self.config.rollout.temperature)
-        cfg_scale = prompts.meta_info.get("cfg_scale", self.config.rollout.get("cfg_scale", 0.0))
-        remasking = prompts.meta_info.get("remasking", "low_confidence")
-        MASK_TOKEN_ID = self.actor_module_fsdp.config.mask_token_id
-
-        total_steps = num_diffusion_steps
-        s = tree_contraction_factor
-        branch_points = [total_steps] + [total_steps - int(k * total_steps / s) for k in range(1, s + 1)]
-        branch_points = sorted(list(set(branch_points)), reverse=True)
-
-        # Initialize root: prompt + all-mask completion
-        seq_len = prompt_length + response_length
-        initial_gen = torch.full((batch_size, seq_len), MASK_TOKEN_ID, dtype=torch.long, device=device)
-        initial_gen[:, :prompt_length] = input_ids
-        # Build attention mask for full sequence (ensure on same device as input_ids)
-        full_attn = torch.cat([attention_mask.to(device), torch.ones(batch_size, response_length, device=device, dtype=attention_mask.dtype)], dim=1)
-
-        prompt_index = torch.zeros(batch_size, seq_len, dtype=torch.bool, device=device)
-        prompt_index[:, :prompt_length] = True
-
-        # Build tree
-        import uuid as uuid_mod
-
-        root_id = "root"
-        all_nodes = {
-            root_id: {
-                "id": root_id, "parent_id": None, "generation": initial_gen, "step": total_steps,
-                "children": [], "value_vec": torch.zeros(batch_size, device=device), "is_leaf": False,
-            }
-        }
-        current_level = [all_nodes[root_id]]
-
-        self.actor_module_fsdp.eval()
-        with torch.no_grad(), torch.autocast(device_type="cuda", dtype=torch.bfloat16):
-            for i in range(len(branch_points) - 1):
-                start_step, end_step = branch_points[i], branch_points[i + 1]
-                steps_to_run = start_step - end_step
-                next_level = []
-
-                for node in current_level:
-                    bf = num_tree_samples if node["id"] == root_id else tree_branch_factor
-                    for k in range(bf):
-                        new_gen = self._tree_generate_partial(
-                            model=self.actor_module_fsdp,
-                            start_generation=node["generation"],
-                            prompt_index=prompt_index,
-                            prompt_length=prompt_length,
-                            response_length=response_length,
-                            block_length=block_length,
-                            current_step=start_step,
-                            steps_to_run=steps_to_run,
-                            total_diffusion_steps=total_steps,
-                            temperature=temperature,
-                            cfg_scale=cfg_scale,
-                            remasking=remasking,
-                            MASK_TOKEN_ID=MASK_TOKEN_ID,
-                            full_attn=full_attn,
-                        )
-                        child_id = str(uuid_mod.uuid4())
-                        child_node = {
-                            "id": child_id, "parent_id": node["id"], "generation": new_gen,
-                            "step": end_step, "children": [], "value_vec": None,
-                            "is_leaf": (end_step == 0),
-                        }
-                        all_nodes[child_id] = child_node
-                        node["children"].append(child_id)
-                        next_level.append(child_node)
-
-                current_level = next_level
-
-        # Collect leaf generations for reward computation
-        leaf_nodes = [n for n in all_nodes.values() if n["is_leaf"]]
-        leaf_ids_list = []
-        leaf_node_ids = []
-        for leaf in leaf_nodes:
-            leaf_ids_list.append(leaf["generation"])  # (batch_size, seq_len)
-            leaf_node_ids.append(leaf["id"])
-
-        if not leaf_ids_list:
-            # No leaves generated, return empty
-            return DataProto.from_dict(tensors={"leaf_input_ids": torch.zeros(0, seq_len, device="cpu", dtype=torch.long)})
-
-        # Stack leaf_input_ids: (num_leaves, batch_size, seq_len)
-        leaf_input_ids = torch.stack(leaf_ids_list, dim=0)
-        leaf_responses = leaf_input_ids[:, :, prompt_length:]  # (num_leaves, batch_size, response_length)
-        leaf_attn = full_attn.unsqueeze(0).expand(len(leaf_nodes), -1, -1)
-
-        # Serialize tree structure
-        node_ids = list(all_nodes.keys())
-        node_id_to_idx = {nid: idx for idx, nid in enumerate(node_ids)}
-        num_nodes = len(node_ids)
-
-        node_generations = torch.stack([all_nodes[nid]["generation"] for nid in node_ids], dim=0)  # (num_nodes, batch_size, seq_len)
-        node_steps = torch.tensor([all_nodes[nid]["step"] for nid in node_ids], dtype=torch.long, device=device)
-        node_is_leaf = torch.tensor([all_nodes[nid]["is_leaf"] for nid in node_ids], dtype=torch.bool, device=device)
-        node_parent_idx = torch.tensor(
-            [node_id_to_idx.get(all_nodes[nid]["parent_id"], -1) if all_nodes[nid]["parent_id"] else -1 for nid in node_ids],
-            dtype=torch.long, device=device
-        )
-        max_children = max(len(all_nodes[nid]["children"]) for nid in node_ids)
-        max_children = max(max_children, 1)
-        node_children_idx = torch.full((num_nodes, max_children), -1, dtype=torch.long, device=device)
-        for i, nid in enumerate(node_ids):
-            for j, cid in enumerate(all_nodes[nid]["children"]):
-                node_children_idx[i, j] = node_id_to_idx[cid]
-
-        num_leaves_val = len(leaf_nodes)
-        response_length_val = response_length
-
-        # DP_COMPUTE_PROTO splits/concats on dim0, which must be batch_size.
-        # Reshape so dim0 = batch_size (per GPU), putting node/leaf dims into dim1+.
-        # node_generations: (num_nodes, B, seq_len) → (B, num_nodes, seq_len)
-        # leaf_input_ids:   (num_leaves, B, seq_len) → (B, num_leaves, seq_len)
-        # leaf_responses:   (num_leaves, B, resp_len) → (B, num_leaves, resp_len)
-        # leaf_attn:        (num_leaves, B, seq_len)  → (B, num_leaves, seq_len)
-        # Tree structure tensors (same for all batch items) → replicate to (B, ...)
-        node_gen_bt = node_generations.permute(1, 0, 2).contiguous().to("cpu")   # (B, num_nodes, seq_len)
-        leaf_ids_bt = leaf_input_ids.permute(1, 0, 2).contiguous().to("cpu")     # (B, num_leaves, seq_len)
-        leaf_resp_bt = leaf_responses.permute(1, 0, 2).contiguous().to("cpu")    # (B, num_leaves, resp_len)
-        leaf_attn_bt = leaf_attn.permute(1, 0, 2).contiguous().to("cpu")        # (B, num_leaves, seq_len)
-
-        # Tree structure: expand to (B, ...) for uniform batch dim
-        node_steps_bt = node_steps.unsqueeze(0).expand(batch_size, -1).contiguous().to("cpu")       # (B, num_nodes)
-        node_is_leaf_bt = node_is_leaf.unsqueeze(0).expand(batch_size, -1).contiguous().to("cpu")   # (B, num_nodes)
-        node_parent_bt = node_parent_idx.unsqueeze(0).expand(batch_size, -1).contiguous().to("cpu") # (B, num_nodes)
-        node_children_bt = node_children_idx.unsqueeze(0).expand(batch_size, -1, -1).contiguous().to("cpu")  # (B, num_nodes, max_children)
-
-        result = DataProto.from_dict(
-            tensors={
-                "node_generations": node_gen_bt,     # (B, num_nodes, seq_len)
-                "node_steps": node_steps_bt,         # (B, num_nodes)
-                "node_is_leaf": node_is_leaf_bt,     # (B, num_nodes)
-                "node_parent_idx": node_parent_bt,   # (B, num_nodes)
-                "node_children_idx": node_children_bt,  # (B, num_nodes, max_children)
-                "leaf_input_ids": leaf_ids_bt,       # (B, num_leaves, seq_len)
-                "leaf_responses": leaf_resp_bt,      # (B, num_leaves, resp_len)
-                "leaf_attn": leaf_attn_bt,           # (B, num_leaves, seq_len)
-            },
-        )
-        result.meta_info["batch_size_per_gpu"] = batch_size
-        result.meta_info["prompt_length"] = prompt_length
-        result.meta_info["num_leaves"] = num_leaves_val
-        result.meta_info["num_nodes"] = num_nodes
-        result.meta_info["branch_points"] = branch_points
-        return result
-
-    def _tree_generate_partial(
-        self, model, start_generation, prompt_index, prompt_length, response_length,
-        block_length, current_step, steps_to_run, total_diffusion_steps,
-        temperature, cfg_scale, remasking, MASK_TOKEN_ID, full_attn,
-    ):
-        """Partially denoise from current_step for steps_to_run steps."""
-        from verl.workers.rollout.generate import add_gumbel_noise, get_num_transfer_tokens
-
-        x = start_generation.clone()
-        device = x.device
-        gen_length = response_length
-        num_blocks = gen_length // block_length
-        steps_per_block = total_diffusion_steps // num_blocks
-
-        target_step = max(0, current_step - steps_to_run)
-        current_block_idx = (total_diffusion_steps - current_step) // steps_per_block
-        target_block_idx = (total_diffusion_steps - target_step) // steps_per_block
-        blocks_to_process = list(range(current_block_idx, min(target_block_idx + 1, num_blocks)))
-        if not blocks_to_process:
-            return x
-
-        remaining_steps = steps_to_run
-
-        for block_idx in blocks_to_process:
-            if remaining_steps <= 0:
-                break
-
-            start_idx = prompt_length + block_idx * block_length
-            end_idx = prompt_length + (block_idx + 1) * block_length
-
-            block_step_start = total_diffusion_steps - block_idx * steps_per_block
-            block_step_end = total_diffusion_steps - (block_idx + 1) * steps_per_block
-            actual_start = min(current_step, block_step_start)
-            actual_end = max(target_step, block_step_end)
-            steps_needed = max(0, actual_start - actual_end)
-            if steps_needed <= 0:
-                continue
-
-            done_in_block = max(0, min(block_step_start - current_step, steps_per_block))
-            remain_in_block = steps_per_block - done_in_block
-            if remain_in_block <= 0:
-                continue
-
-            steps_in_this_block = min(steps_needed, remaining_steps, remain_in_block)
-            if steps_in_this_block <= 0:
-                continue
-
-            block_mask_now = x[:, start_idx:end_idx] == MASK_TOKEN_ID
-            schedule = get_num_transfer_tokens(block_mask_now, remain_in_block)
-
-            for step_i in range(steps_in_this_block):
-                block_mask_step = x[:, start_idx:end_idx] == MASK_TOKEN_ID
-                budget = schedule[:, step_i]
-                mask_index_full = x == MASK_TOKEN_ID
-
-                # Use packed input for efficient forward
-                batch_size = x.size(0)
-                packed = []
-                cu_seqlens = [0]
-                max_seqlen = 0
-                for b in range(batch_size):
-                    valid = x[b][full_attn[b] == 1]
-                    packed.append(valid)
-                    cu_seqlens.append(cu_seqlens[-1] + len(valid))
-                    max_seqlen = max(max_seqlen, len(valid))
-                packed_input = torch.cat(packed, dim=0).unsqueeze(0)
-                cu_seqlens_t = torch.tensor(cu_seqlens, dtype=torch.int32, device=device)
-
-                if cfg_scale > 0.0:
-                    un_packed = packed_input.clone()
-                    for b in range(batch_size):
-                        plen = full_attn[b, :prompt_length].sum().item()
-                        un_packed[0, cu_seqlens[b]:cu_seqlens[b] + plen] = MASK_TOKEN_ID
-                    packed_cat = torch.cat([packed_input, un_packed], dim=0)
-                    cu_cat = torch.cat([cu_seqlens_t, cu_seqlens_t[1:] + cu_seqlens_t[-1]], dim=0)
-                    logits = model(packed_cat, cu_seqlens=cu_cat, max_seqlen=max_seqlen).logits
-                    logits, un_logits = torch.chunk(logits, 2, dim=0)
-                    logits = un_logits + (cfg_scale + 1) * (logits - un_logits)
-                else:
-                    logits = model(packed_input, cu_seqlens=cu_seqlens_t, max_seqlen=max_seqlen).logits
-
-                # Unpack logits to padded form
-                seq_len = x.size(1)
-                full_logits = torch.zeros(batch_size, seq_len, logits.size(-1), device=device, dtype=logits.dtype)
-                for b in range(batch_size):
-                    full_logits[b, full_attn[b] == 1] = logits[0, cu_seqlens[b]:cu_seqlens[b + 1]]
-
-                # Dream model requires shifted logits for correct token prediction
-                if self.config.model.name == 'dream':
-                    full_logits = torch.cat([full_logits[:, :1], full_logits[:, :-1]], dim=1)
-
-                logits_with_noise = add_gumbel_noise(full_logits, temperature)
-                x0 = torch.argmax(logits_with_noise, dim=-1)
-
-                if remasking == "low_confidence":
-                    p = torch.softmax(full_logits.float(), dim=-1)
-                    x0_p = torch.gather(p, dim=-1, index=x0.unsqueeze(-1)).squeeze(-1)
-                elif remasking == "random":
-                    x0_p = torch.rand_like(x0, dtype=torch.float32)
-                else:
-                    raise NotImplementedError(f"Remasking '{remasking}' not implemented")
-
-                x0_p[:, :start_idx] = -float('inf')
-                x0_p[:, end_idx:] = -float('inf')
-                x0 = torch.where(mask_index_full, x0, x)
-                confidence = torch.where(mask_index_full, x0_p, -torch.inf)
-
-                transfer_index = torch.zeros_like(x0, dtype=torch.bool, device=device)
-                for b in range(batch_size):
-                    k_plan = int(budget[b].item())
-                    if k_plan <= 0:
-                        continue
-                    k_avail = int(block_mask_step[b].sum().item())
-                    if k_avail <= 0:
-                        continue
-                    k = min(k_plan, k_avail)
-                    _, candidate_idx = torch.topk(confidence[b], k=k)
-                    transfer_index[b, candidate_idx] = True
-
-                transfer_index = transfer_index & ~prompt_index
-                x[transfer_index] = x0[transfer_index]
-
-            remaining_steps -= steps_in_this_block
-
-        return x
 
     @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)
     def compute_dtreerpo_log_prob(self, data: DataProto):

--- a/verl/workers/dllm_fsdp_workers.py
+++ b/verl/workers/dllm_fsdp_workers.py
@@ -209,7 +209,7 @@ class DLLMActorRolloutRefWorker(ActorRolloutRefWorker):
                     'lora_alpha': self.config.model.lora_alpha,
                     'target_modules': convert_to_regular_types(self.config.model.target_modules),
                     'bias': "none",
-                    # 'lora_dropout': self.config.model.lora_dropout,  # LNY: add dropout
+                    'lora_dropout': self.config.model.get('lora_dropout', 0.0),
                 }
                 actor_module = get_peft_model(actor_module, LoraConfig(**lora_config))
                 actor_module.print_trainable_parameters()
@@ -568,6 +568,8 @@ class DLLMActorRolloutRefWorker(ActorRolloutRefWorker):
                 from verl.workers.actor.llada_dp_actor_vrpo import DLLMDataParallelPPOActor
             elif self.config.algorithm.name == 'mdpo':
                 from verl.workers.actor.llada_dp_actor_mdpo import DLLMDataParallelPPOActor
+            elif self.config.algorithm.name == 'dtreerpo':
+                from verl.workers.actor.llada_dp_actor_dtreerpo import DLLMDataParallelPPOActor
             else:
                 raise NotImplementedError
 
@@ -594,6 +596,8 @@ class DLLMActorRolloutRefWorker(ActorRolloutRefWorker):
                 from verl.workers.actor.dream_dp_actor_vrpo import DLLMDataParallelPPOActor
             elif self.config.algorithm.name == 'mdpo':
                 from verl.workers.actor.dream_dp_actor_mdpo import DLLMDataParallelPPOActor
+            elif self.config.algorithm.name == 'dtreerpo':
+                from verl.workers.actor.dream_dp_actor_dtreerpo import DLLMDataParallelPPOActor
             else:
                 raise NotImplementedError
 
@@ -907,6 +911,8 @@ class DLLMActorRolloutRefWorker(ActorRolloutRefWorker):
         
         elif self.config.algorithm.name == "mdpo":
             raise RuntimeError("MDPO does not use forward_process. The diffusion trajectory is collected during rollout.")
+        elif self.config.algorithm.name == "dtreerpo":
+            raise RuntimeError("d-TreeRPO does not use forward_process. Tree search is performed via tree_search_generate.")
         else:
             raise NotImplementedError(f"Unsupported algorithm: {self.config.algorithm.name} for forward process in DLLMActorRolloutRefWorker")
         batch = TensorDict(
@@ -924,6 +930,327 @@ class DLLMActorRolloutRefWorker(ActorRolloutRefWorker):
         )
         
         return DataProto(batch=batch)
+
+    @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)
+    def tree_search_generate(self, prompts: DataProto):
+        """
+        d-TreeRPO tree search: build a tree of partial generations with branching at predefined diffusion steps.
+        Returns all node data for reward computation and training segment construction.
+        """
+        from verl.workers.rollout.generate import add_gumbel_noise, get_num_transfer_tokens
+        import torch.nn.functional as F
+
+        batch = prompts.batch
+        input_ids = batch["input_ids"]  # (batch_size, prompt_len)
+        attention_mask = batch["attention_mask"]
+        batch_size = input_ids.size(0)
+        prompt_length = input_ids.size(1)
+        # Ensure tensors are on GPU (Ray may pass CPU tensors)
+        device = next(self.actor_module_fsdp.parameters()).device
+        input_ids = input_ids.to(device)
+        attention_mask = attention_mask.to(device)
+
+        # Tree search config from meta_info
+        response_length = prompts.meta_info.get("response_length", self.config.rollout.get("response_length"))
+        num_diffusion_steps = prompts.meta_info.get("num_diffusion_steps", self.config.rollout.get("num_diffusion_steps"))
+        block_length = prompts.meta_info.get("block_length", self.config.rollout.get("block_length"))
+        tree_branch_factor = prompts.meta_info.get("tree_branch_factor", 4)
+        tree_contraction_factor = prompts.meta_info.get("tree_contraction_factor", 2)
+        num_tree_samples = prompts.meta_info.get("num_tree_samples", 4)
+        temperature = prompts.meta_info.get("temperature", self.config.rollout.temperature)
+        cfg_scale = prompts.meta_info.get("cfg_scale", self.config.rollout.get("cfg_scale", 0.0))
+        remasking = prompts.meta_info.get("remasking", "low_confidence")
+        MASK_TOKEN_ID = self.actor_module_fsdp.config.mask_token_id
+
+        total_steps = num_diffusion_steps
+        s = tree_contraction_factor
+        branch_points = [total_steps] + [total_steps - int(k * total_steps / s) for k in range(1, s + 1)]
+        branch_points = sorted(list(set(branch_points)), reverse=True)
+
+        # Initialize root: prompt + all-mask completion
+        seq_len = prompt_length + response_length
+        initial_gen = torch.full((batch_size, seq_len), MASK_TOKEN_ID, dtype=torch.long, device=device)
+        initial_gen[:, :prompt_length] = input_ids
+        # Build attention mask for full sequence (ensure on same device as input_ids)
+        full_attn = torch.cat([attention_mask.to(device), torch.ones(batch_size, response_length, device=device, dtype=attention_mask.dtype)], dim=1)
+
+        prompt_index = torch.zeros(batch_size, seq_len, dtype=torch.bool, device=device)
+        prompt_index[:, :prompt_length] = True
+
+        # Build tree
+        import uuid as uuid_mod
+
+        root_id = "root"
+        all_nodes = {
+            root_id: {
+                "id": root_id, "parent_id": None, "generation": initial_gen, "step": total_steps,
+                "children": [], "value_vec": torch.zeros(batch_size, device=device), "is_leaf": False,
+            }
+        }
+        current_level = [all_nodes[root_id]]
+
+        self.actor_module_fsdp.eval()
+        with torch.no_grad(), torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+            for i in range(len(branch_points) - 1):
+                start_step, end_step = branch_points[i], branch_points[i + 1]
+                steps_to_run = start_step - end_step
+                next_level = []
+
+                for node in current_level:
+                    bf = num_tree_samples if node["id"] == root_id else tree_branch_factor
+                    for k in range(bf):
+                        new_gen = self._tree_generate_partial(
+                            model=self.actor_module_fsdp,
+                            start_generation=node["generation"],
+                            prompt_index=prompt_index,
+                            prompt_length=prompt_length,
+                            response_length=response_length,
+                            block_length=block_length,
+                            current_step=start_step,
+                            steps_to_run=steps_to_run,
+                            total_diffusion_steps=total_steps,
+                            temperature=temperature,
+                            cfg_scale=cfg_scale,
+                            remasking=remasking,
+                            MASK_TOKEN_ID=MASK_TOKEN_ID,
+                            full_attn=full_attn,
+                        )
+                        child_id = str(uuid_mod.uuid4())
+                        child_node = {
+                            "id": child_id, "parent_id": node["id"], "generation": new_gen,
+                            "step": end_step, "children": [], "value_vec": None,
+                            "is_leaf": (end_step == 0),
+                        }
+                        all_nodes[child_id] = child_node
+                        node["children"].append(child_id)
+                        next_level.append(child_node)
+
+                current_level = next_level
+
+        # Collect leaf generations for reward computation
+        leaf_nodes = [n for n in all_nodes.values() if n["is_leaf"]]
+        leaf_ids_list = []
+        leaf_node_ids = []
+        for leaf in leaf_nodes:
+            leaf_ids_list.append(leaf["generation"])  # (batch_size, seq_len)
+            leaf_node_ids.append(leaf["id"])
+
+        if not leaf_ids_list:
+            # No leaves generated, return empty
+            return DataProto.from_dict(tensors={"leaf_input_ids": torch.zeros(0, seq_len, device="cpu", dtype=torch.long)})
+
+        # Stack leaf_input_ids: (num_leaves, batch_size, seq_len)
+        leaf_input_ids = torch.stack(leaf_ids_list, dim=0)
+        leaf_responses = leaf_input_ids[:, :, prompt_length:]  # (num_leaves, batch_size, response_length)
+        leaf_attn = full_attn.unsqueeze(0).expand(len(leaf_nodes), -1, -1)
+
+        # Serialize tree structure
+        node_ids = list(all_nodes.keys())
+        node_id_to_idx = {nid: idx for idx, nid in enumerate(node_ids)}
+        num_nodes = len(node_ids)
+
+        node_generations = torch.stack([all_nodes[nid]["generation"] for nid in node_ids], dim=0)  # (num_nodes, batch_size, seq_len)
+        node_steps = torch.tensor([all_nodes[nid]["step"] for nid in node_ids], dtype=torch.long, device=device)
+        node_is_leaf = torch.tensor([all_nodes[nid]["is_leaf"] for nid in node_ids], dtype=torch.bool, device=device)
+        node_parent_idx = torch.tensor(
+            [node_id_to_idx.get(all_nodes[nid]["parent_id"], -1) if all_nodes[nid]["parent_id"] else -1 for nid in node_ids],
+            dtype=torch.long, device=device
+        )
+        max_children = max(len(all_nodes[nid]["children"]) for nid in node_ids)
+        max_children = max(max_children, 1)
+        node_children_idx = torch.full((num_nodes, max_children), -1, dtype=torch.long, device=device)
+        for i, nid in enumerate(node_ids):
+            for j, cid in enumerate(all_nodes[nid]["children"]):
+                node_children_idx[i, j] = node_id_to_idx[cid]
+
+        num_leaves_val = len(leaf_nodes)
+        response_length_val = response_length
+
+        # DP_COMPUTE_PROTO splits/concats on dim0, which must be batch_size.
+        # Reshape so dim0 = batch_size (per GPU), putting node/leaf dims into dim1+.
+        # node_generations: (num_nodes, B, seq_len) → (B, num_nodes, seq_len)
+        # leaf_input_ids:   (num_leaves, B, seq_len) → (B, num_leaves, seq_len)
+        # leaf_responses:   (num_leaves, B, resp_len) → (B, num_leaves, resp_len)
+        # leaf_attn:        (num_leaves, B, seq_len)  → (B, num_leaves, seq_len)
+        # Tree structure tensors (same for all batch items) → replicate to (B, ...)
+        node_gen_bt = node_generations.permute(1, 0, 2).contiguous().to("cpu")   # (B, num_nodes, seq_len)
+        leaf_ids_bt = leaf_input_ids.permute(1, 0, 2).contiguous().to("cpu")     # (B, num_leaves, seq_len)
+        leaf_resp_bt = leaf_responses.permute(1, 0, 2).contiguous().to("cpu")    # (B, num_leaves, resp_len)
+        leaf_attn_bt = leaf_attn.permute(1, 0, 2).contiguous().to("cpu")        # (B, num_leaves, seq_len)
+
+        # Tree structure: expand to (B, ...) for uniform batch dim
+        node_steps_bt = node_steps.unsqueeze(0).expand(batch_size, -1).contiguous().to("cpu")       # (B, num_nodes)
+        node_is_leaf_bt = node_is_leaf.unsqueeze(0).expand(batch_size, -1).contiguous().to("cpu")   # (B, num_nodes)
+        node_parent_bt = node_parent_idx.unsqueeze(0).expand(batch_size, -1).contiguous().to("cpu") # (B, num_nodes)
+        node_children_bt = node_children_idx.unsqueeze(0).expand(batch_size, -1, -1).contiguous().to("cpu")  # (B, num_nodes, max_children)
+
+        result = DataProto.from_dict(
+            tensors={
+                "node_generations": node_gen_bt,     # (B, num_nodes, seq_len)
+                "node_steps": node_steps_bt,         # (B, num_nodes)
+                "node_is_leaf": node_is_leaf_bt,     # (B, num_nodes)
+                "node_parent_idx": node_parent_bt,   # (B, num_nodes)
+                "node_children_idx": node_children_bt,  # (B, num_nodes, max_children)
+                "leaf_input_ids": leaf_ids_bt,       # (B, num_leaves, seq_len)
+                "leaf_responses": leaf_resp_bt,      # (B, num_leaves, resp_len)
+                "leaf_attn": leaf_attn_bt,           # (B, num_leaves, seq_len)
+            },
+        )
+        result.meta_info["batch_size_per_gpu"] = batch_size
+        result.meta_info["prompt_length"] = prompt_length
+        result.meta_info["num_leaves"] = num_leaves_val
+        result.meta_info["num_nodes"] = num_nodes
+        result.meta_info["branch_points"] = branch_points
+        return result
+
+    def _tree_generate_partial(
+        self, model, start_generation, prompt_index, prompt_length, response_length,
+        block_length, current_step, steps_to_run, total_diffusion_steps,
+        temperature, cfg_scale, remasking, MASK_TOKEN_ID, full_attn,
+    ):
+        """Partially denoise from current_step for steps_to_run steps."""
+        from verl.workers.rollout.generate import add_gumbel_noise, get_num_transfer_tokens
+
+        x = start_generation.clone()
+        device = x.device
+        gen_length = response_length
+        num_blocks = gen_length // block_length
+        steps_per_block = total_diffusion_steps // num_blocks
+
+        target_step = max(0, current_step - steps_to_run)
+        current_block_idx = (total_diffusion_steps - current_step) // steps_per_block
+        target_block_idx = (total_diffusion_steps - target_step) // steps_per_block
+        blocks_to_process = list(range(current_block_idx, min(target_block_idx + 1, num_blocks)))
+        if not blocks_to_process:
+            return x
+
+        remaining_steps = steps_to_run
+
+        for block_idx in blocks_to_process:
+            if remaining_steps <= 0:
+                break
+
+            start_idx = prompt_length + block_idx * block_length
+            end_idx = prompt_length + (block_idx + 1) * block_length
+
+            block_step_start = total_diffusion_steps - block_idx * steps_per_block
+            block_step_end = total_diffusion_steps - (block_idx + 1) * steps_per_block
+            actual_start = min(current_step, block_step_start)
+            actual_end = max(target_step, block_step_end)
+            steps_needed = max(0, actual_start - actual_end)
+            if steps_needed <= 0:
+                continue
+
+            done_in_block = max(0, min(block_step_start - current_step, steps_per_block))
+            remain_in_block = steps_per_block - done_in_block
+            if remain_in_block <= 0:
+                continue
+
+            steps_in_this_block = min(steps_needed, remaining_steps, remain_in_block)
+            if steps_in_this_block <= 0:
+                continue
+
+            block_mask_now = x[:, start_idx:end_idx] == MASK_TOKEN_ID
+            schedule = get_num_transfer_tokens(block_mask_now, remain_in_block)
+
+            for step_i in range(steps_in_this_block):
+                block_mask_step = x[:, start_idx:end_idx] == MASK_TOKEN_ID
+                budget = schedule[:, step_i]
+                mask_index_full = x == MASK_TOKEN_ID
+
+                # Use packed input for efficient forward
+                batch_size = x.size(0)
+                packed = []
+                cu_seqlens = [0]
+                max_seqlen = 0
+                for b in range(batch_size):
+                    valid = x[b][full_attn[b] == 1]
+                    packed.append(valid)
+                    cu_seqlens.append(cu_seqlens[-1] + len(valid))
+                    max_seqlen = max(max_seqlen, len(valid))
+                packed_input = torch.cat(packed, dim=0).unsqueeze(0)
+                cu_seqlens_t = torch.tensor(cu_seqlens, dtype=torch.int32, device=device)
+
+                if cfg_scale > 0.0:
+                    un_packed = packed_input.clone()
+                    for b in range(batch_size):
+                        plen = full_attn[b, :prompt_length].sum().item()
+                        un_packed[0, cu_seqlens[b]:cu_seqlens[b] + plen] = MASK_TOKEN_ID
+                    packed_cat = torch.cat([packed_input, un_packed], dim=0)
+                    cu_cat = torch.cat([cu_seqlens_t, cu_seqlens_t[1:] + cu_seqlens_t[-1]], dim=0)
+                    logits = model(packed_cat, cu_seqlens=cu_cat, max_seqlen=max_seqlen).logits
+                    logits, un_logits = torch.chunk(logits, 2, dim=0)
+                    logits = un_logits + (cfg_scale + 1) * (logits - un_logits)
+                else:
+                    logits = model(packed_input, cu_seqlens=cu_seqlens_t, max_seqlen=max_seqlen).logits
+
+                # Unpack logits to padded form
+                seq_len = x.size(1)
+                full_logits = torch.zeros(batch_size, seq_len, logits.size(-1), device=device, dtype=logits.dtype)
+                for b in range(batch_size):
+                    full_logits[b, full_attn[b] == 1] = logits[0, cu_seqlens[b]:cu_seqlens[b + 1]]
+
+                # Dream model requires shifted logits for correct token prediction
+                if self.config.model.name == 'dream':
+                    full_logits = torch.cat([full_logits[:, :1], full_logits[:, :-1]], dim=1)
+
+                logits_with_noise = add_gumbel_noise(full_logits, temperature)
+                x0 = torch.argmax(logits_with_noise, dim=-1)
+
+                if remasking == "low_confidence":
+                    p = torch.softmax(full_logits.float(), dim=-1)
+                    x0_p = torch.gather(p, dim=-1, index=x0.unsqueeze(-1)).squeeze(-1)
+                elif remasking == "random":
+                    x0_p = torch.rand_like(x0, dtype=torch.float32)
+                else:
+                    raise NotImplementedError(f"Remasking '{remasking}' not implemented")
+
+                x0_p[:, :start_idx] = -float('inf')
+                x0_p[:, end_idx:] = -float('inf')
+                x0 = torch.where(mask_index_full, x0, x)
+                confidence = torch.where(mask_index_full, x0_p, -torch.inf)
+
+                transfer_index = torch.zeros_like(x0, dtype=torch.bool, device=device)
+                for b in range(batch_size):
+                    k_plan = int(budget[b].item())
+                    if k_plan <= 0:
+                        continue
+                    k_avail = int(block_mask_step[b].sum().item())
+                    if k_avail <= 0:
+                        continue
+                    k = min(k_plan, k_avail)
+                    _, candidate_idx = torch.topk(confidence[b], k=k)
+                    transfer_index[b, candidate_idx] = True
+
+                transfer_index = transfer_index & ~prompt_index
+                x[transfer_index] = x0[transfer_index]
+
+            remaining_steps -= steps_in_this_block
+
+        return x
+
+    @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)
+    def compute_dtreerpo_log_prob(self, data: DataProto):
+        """Compute old local transition log probs for d-TreeRPO training segments."""
+        assert self._is_actor
+        if self._is_offload_param:
+            load_fsdp_model_to_gpu(self.actor_module_fsdp)
+
+        data = data.to(get_torch_device().current_device())
+        data.meta_info["micro_batch_size"] = self.config.rollout.log_prob_micro_batch_size_per_gpu
+        data.meta_info["cfg_scale"] = self.config.rollout.get("cfg_scale", 0.0)
+
+        with self.ulysses_sharding_manager:
+            data = self.ulysses_sharding_manager.preprocess_data(data)
+            _, local_logps, _ = self.actor.compute_log_prob(data=data)
+            output = DataProto.from_dict(
+                tensors={"old_local_logps": local_logps},
+            )
+            output = self.ulysses_sharding_manager.postprocess_data(output)
+
+        output = output.to("cpu")
+        get_torch_device().empty_cache()
+        return output
 
     @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)
     def compute_log_prob(self, data: DataProto):
@@ -1037,12 +1364,13 @@ class DLLMActorRolloutRefWorker(ActorRolloutRefWorker):
         self.checkpoint_manager.save_checkpoint(local_path=local_path, hdfs_path=hdfs_path, global_step=global_step, max_ckpt_to_keep=max_ckpt_to_keep)
         dist.barrier()
 
-        if self._is_lora and isinstance(self.actor_module, PeftModel):
+        actor_module = getattr(self, 'actor_module', self.actor_module_fsdp)
+        if self._is_lora and isinstance(actor_module, PeftModel):
             lora_save_path = os.path.join(local_path, "lora_adapter")
             peft_config = {}
             if dist.get_rank() == 0:
                 os.makedirs(lora_save_path, exist_ok=True)
-                peft_config = asdict(self.actor_module.peft_config.get('default', {}))
+                peft_config = asdict(actor_module.peft_config.get('default', {}))
                 peft_config['task_type'] = peft_config['task_type'].value
                 peft_config['peft_type'] = peft_config['peft_type'].value
                 peft_config['target_modules'] = list(peft_config['target_modules'])

--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -750,12 +750,13 @@ class ActorRolloutRefWorker(Worker):
         self.checkpoint_manager.save_checkpoint(local_path=local_path, hdfs_path=hdfs_path, global_step=global_step, max_ckpt_to_keep=max_ckpt_to_keep)
         dist.barrier()
 
-        if self._is_lora and isinstance(self.actor_module, PeftModel):
+        actor_module = getattr(self, 'actor_module', self.actor_module_fsdp)
+        if self._is_lora and isinstance(actor_module, PeftModel):
             lora_save_path = os.path.join(local_path, "lora_adapter")
             peft_config = {}
             if dist.get_rank() == 0:
                 os.makedirs(lora_save_path, exist_ok=True)
-                peft_config = asdict(self.actor_module.peft_config.get('default', {}))
+                peft_config = asdict(actor_module.peft_config.get('default', {}))
                 peft_config['task_type'] = peft_config['task_type'].value
                 peft_config['peft_type'] = peft_config['peft_type'].value
                 peft_config['target_modules'] = list(peft_config['target_modules'])

--- a/verl/workers/reward_manager/dapo.py
+++ b/verl/workers/reward_manager/dapo.py
@@ -71,7 +71,10 @@ class DAPORewardManager:
             valid_response_length = data_item.batch["attention_mask"][prompt_length:].sum()
             valid_response_ids = response_ids[:valid_response_length]
 
-            # decode
+            # decode (filter out-of-vocab token IDs that map to None)
+            vocab_size = len(self.tokenizer)
+            valid_prompt_ids = valid_prompt_ids[valid_prompt_ids < vocab_size]
+            valid_response_ids = valid_response_ids[valid_response_ids < vocab_size]
             prompt_str = self.tokenizer.decode(valid_prompt_ids, skip_special_tokens=True)
             response_str = self.tokenizer.decode(valid_response_ids, skip_special_tokens=True)
             eos_token = self.tokenizer.eos_token

--- a/verl/workers/rollout/dtreerpo_llada_rollout.py
+++ b/verl/workers/rollout/dtreerpo_llada_rollout.py
@@ -1,0 +1,342 @@
+# Copyright 2025 Shanghai AI Lab
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+d-TreeRPO rollout for LLaDA that performs tree search with branching at
+predefined diffusion steps. Builds a tree of partial generations and returns
+all node data for reward computation and training segment construction.
+"""
+
+import uuid as uuid_mod
+
+import torch
+import torch.distributed as dist
+from torch import nn
+from tensordict import TensorDict
+
+from verl import DataProto
+from verl.workers.rollout.base import BaseRollout
+from verl.workers.rollout.generate import add_gumbel_noise, get_num_transfer_tokens
+
+
+__all__ = ["DTreeRPORollout"]
+
+
+class DTreeRPORollout(BaseRollout):
+    def __init__(self, module: nn.Module, config, tokenizer):
+        """d-TreeRPO rollout for LLaDA that performs tree search generation."""
+        super().__init__()
+        self.config = config
+        self.module = module
+        self.tokenizer = tokenizer
+        self.MASK_TOKEN_ID = self.module.config.mask_token_id
+
+        # diffusion related parameters
+        self.response_length = config["response_length"]
+        self.num_diffusion_steps = config["num_diffusion_steps"]
+        self.block_length = config["block_length"]
+        self.cfg_scale = config.get("cfg_scale", 0.0)
+        self.temperature = config["temperature"]
+
+        # model name for dream compatibility
+        self.model_name = config.get("model_name", "llada")
+
+    @torch.no_grad()
+    def generate_sequences(self, prompts: DataProto) -> DataProto:
+        """
+        Perform d-TreeRPO tree search: build a tree of partial generations with
+        branching at predefined diffusion steps.
+
+        Returns DataProto containing tree structure for reward computation and
+        training segment construction.
+        """
+        batch = prompts.batch
+        input_ids = batch["input_ids"]  # (batch_size, prompt_len)
+        attention_mask = batch["attention_mask"]
+        batch_size = input_ids.size(0)
+        prompt_length = input_ids.size(1)
+        device = input_ids.device
+
+        # Tree search config from meta_info (algorithm-specific params)
+        response_length = prompts.meta_info.get("response_length", self.response_length)
+        num_diffusion_steps = prompts.meta_info.get("num_diffusion_steps", self.num_diffusion_steps)
+        block_length = prompts.meta_info.get("block_length", self.block_length)
+        tree_branch_factor = prompts.meta_info.get("tree_branch_factor", 4)
+        tree_contraction_factor = prompts.meta_info.get("tree_contraction_factor", 2)
+        num_tree_samples = prompts.meta_info.get("num_tree_samples", 4)
+        temperature = prompts.meta_info.get("temperature", self.temperature)
+        cfg_scale = prompts.meta_info.get("cfg_scale", self.cfg_scale)
+        remasking = prompts.meta_info.get("remasking", "low_confidence")
+        MASK_TOKEN_ID = self.MASK_TOKEN_ID
+
+        total_steps = num_diffusion_steps
+        s = tree_contraction_factor
+        branch_points = [total_steps] + [total_steps - int(k * total_steps / s) for k in range(1, s + 1)]
+        branch_points = sorted(list(set(branch_points)), reverse=True)
+
+        # Initialize root: prompt + all-mask completion
+        seq_len = prompt_length + response_length
+        initial_gen = torch.full((batch_size, seq_len), MASK_TOKEN_ID, dtype=torch.long, device=device)
+        initial_gen[:, :prompt_length] = input_ids
+        # Build attention mask for full sequence
+        full_attn = torch.cat([
+            attention_mask,
+            torch.ones(batch_size, response_length, device=device, dtype=attention_mask.dtype)
+        ], dim=1)
+
+        prompt_index = torch.zeros(batch_size, seq_len, dtype=torch.bool, device=device)
+        prompt_index[:, :prompt_length] = True
+
+        # Build tree
+        root_id = "root"
+        all_nodes = {
+            root_id: {
+                "id": root_id, "parent_id": None, "generation": initial_gen, "step": total_steps,
+                "children": [], "value_vec": torch.zeros(batch_size, device=device), "is_leaf": False,
+            }
+        }
+        current_level = [all_nodes[root_id]]
+
+        self.module.eval()
+        with torch.no_grad(), torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+            for i in range(len(branch_points) - 1):
+                start_step, end_step = branch_points[i], branch_points[i + 1]
+                steps_to_run = start_step - end_step
+                next_level = []
+
+                for node in current_level:
+                    bf = num_tree_samples if node["id"] == root_id else tree_branch_factor
+                    for k in range(bf):
+                        new_gen = self._tree_generate_partial(
+                            model=self.module,
+                            start_generation=node["generation"],
+                            prompt_index=prompt_index,
+                            prompt_length=prompt_length,
+                            response_length=response_length,
+                            block_length=block_length,
+                            current_step=start_step,
+                            steps_to_run=steps_to_run,
+                            total_diffusion_steps=total_steps,
+                            temperature=temperature,
+                            cfg_scale=cfg_scale,
+                            remasking=remasking,
+                            MASK_TOKEN_ID=MASK_TOKEN_ID,
+                            full_attn=full_attn,
+                        )
+                        child_id = str(uuid_mod.uuid4())
+                        child_node = {
+                            "id": child_id, "parent_id": node["id"], "generation": new_gen,
+                            "step": end_step, "children": [], "value_vec": None,
+                            "is_leaf": (end_step == 0),
+                        }
+                        all_nodes[child_id] = child_node
+                        node["children"].append(child_id)
+                        next_level.append(child_node)
+
+                current_level = next_level
+
+        # Collect leaf generations for reward computation
+        leaf_nodes = [n for n in all_nodes.values() if n["is_leaf"]]
+        leaf_ids_list = []
+        for leaf in leaf_nodes:
+            leaf_ids_list.append(leaf["generation"])  # (batch_size, seq_len)
+
+        if not leaf_ids_list:
+            return DataProto.from_dict(
+                tensors={"leaf_input_ids": torch.zeros(0, seq_len, device="cpu", dtype=torch.long)}
+            )
+
+        # Stack leaf_input_ids: (num_leaves, batch_size, seq_len)
+        leaf_input_ids = torch.stack(leaf_ids_list, dim=0)
+        leaf_responses = leaf_input_ids[:, :, prompt_length:]  # (num_leaves, batch_size, response_length)
+        leaf_attn = full_attn.unsqueeze(0).expand(len(leaf_nodes), -1, -1)
+
+        # Serialize tree structure
+        node_ids = list(all_nodes.keys())
+        node_id_to_idx = {nid: idx for idx, nid in enumerate(node_ids)}
+        num_nodes = len(node_ids)
+
+        node_generations = torch.stack([all_nodes[nid]["generation"] for nid in node_ids], dim=0)
+        node_steps = torch.tensor([all_nodes[nid]["step"] for nid in node_ids], dtype=torch.long, device=device)
+        node_is_leaf = torch.tensor([all_nodes[nid]["is_leaf"] for nid in node_ids], dtype=torch.bool, device=device)
+        node_parent_idx = torch.tensor(
+            [node_id_to_idx.get(all_nodes[nid]["parent_id"], -1) if all_nodes[nid]["parent_id"] else -1 for nid in node_ids],
+            dtype=torch.long, device=device
+        )
+        max_children = max(len(all_nodes[nid]["children"]) for nid in node_ids)
+        max_children = max(max_children, 1)
+        node_children_idx = torch.full((num_nodes, max_children), -1, dtype=torch.long, device=device)
+        for i, nid in enumerate(node_ids):
+            for j, cid in enumerate(all_nodes[nid]["children"]):
+                node_children_idx[i, j] = node_id_to_idx[cid]
+
+        num_leaves_val = len(leaf_nodes)
+
+        # DP_COMPUTE_PROTO splits/concats on dim0, which must be batch_size.
+        # Reshape so dim0 = batch_size (per GPU), putting node/leaf dims into dim1+.
+        node_gen_bt = node_generations.permute(1, 0, 2).contiguous().to("cpu")
+        leaf_ids_bt = leaf_input_ids.permute(1, 0, 2).contiguous().to("cpu")
+        leaf_resp_bt = leaf_responses.permute(1, 0, 2).contiguous().to("cpu")
+        leaf_attn_bt = leaf_attn.permute(1, 0, 2).contiguous().to("cpu")
+
+        # Tree structure: expand to (B, ...) for uniform batch dim
+        node_steps_bt = node_steps.unsqueeze(0).expand(batch_size, -1).contiguous().to("cpu")
+        node_is_leaf_bt = node_is_leaf.unsqueeze(0).expand(batch_size, -1).contiguous().to("cpu")
+        node_parent_bt = node_parent_idx.unsqueeze(0).expand(batch_size, -1).contiguous().to("cpu")
+        node_children_bt = node_children_idx.unsqueeze(0).expand(batch_size, -1, -1).contiguous().to("cpu")
+
+        result = DataProto.from_dict(
+            tensors={
+                "node_generations": node_gen_bt,
+                "node_steps": node_steps_bt,
+                "node_is_leaf": node_is_leaf_bt,
+                "node_parent_idx": node_parent_bt,
+                "node_children_idx": node_children_bt,
+                "leaf_input_ids": leaf_ids_bt,
+                "leaf_responses": leaf_resp_bt,
+                "leaf_attn": leaf_attn_bt,
+            },
+        )
+        result.meta_info["batch_size_per_gpu"] = batch_size
+        result.meta_info["prompt_length"] = prompt_length
+        result.meta_info["num_leaves"] = num_leaves_val
+        result.meta_info["num_nodes"] = num_nodes
+        result.meta_info["branch_points"] = branch_points
+
+        self.module.train()
+        return result
+
+    def _tree_generate_partial(
+        self, model, start_generation, prompt_index, prompt_length, response_length,
+        block_length, current_step, steps_to_run, total_diffusion_steps,
+        temperature, cfg_scale, remasking, MASK_TOKEN_ID, full_attn,
+    ):
+        """Partially denoise from current_step for steps_to_run steps."""
+        x = start_generation.clone()
+        device = x.device
+        gen_length = response_length
+        num_blocks = gen_length // block_length
+        steps_per_block = total_diffusion_steps // num_blocks
+
+        target_step = max(0, current_step - steps_to_run)
+        current_block_idx = (total_diffusion_steps - current_step) // steps_per_block
+        target_block_idx = (total_diffusion_steps - target_step) // steps_per_block
+        blocks_to_process = list(range(current_block_idx, min(target_block_idx + 1, num_blocks)))
+        if not blocks_to_process:
+            return x
+
+        remaining_steps = steps_to_run
+
+        for block_idx in blocks_to_process:
+            if remaining_steps <= 0:
+                break
+
+            start_idx = prompt_length + block_idx * block_length
+            end_idx = prompt_length + (block_idx + 1) * block_length
+
+            block_step_start = total_diffusion_steps - block_idx * steps_per_block
+            block_step_end = total_diffusion_steps - (block_idx + 1) * steps_per_block
+            actual_start = min(current_step, block_step_start)
+            actual_end = max(target_step, block_step_end)
+            steps_needed = max(0, actual_start - actual_end)
+            if steps_needed <= 0:
+                continue
+
+            done_in_block = max(0, min(block_step_start - current_step, steps_per_block))
+            remain_in_block = steps_per_block - done_in_block
+            if remain_in_block <= 0:
+                continue
+
+            steps_in_this_block = min(steps_needed, remaining_steps, remain_in_block)
+            if steps_in_this_block <= 0:
+                continue
+
+            block_mask_now = x[:, start_idx:end_idx] == MASK_TOKEN_ID
+            schedule = get_num_transfer_tokens(block_mask_now, remain_in_block)
+
+            for step_i in range(steps_in_this_block):
+                block_mask_step = x[:, start_idx:end_idx] == MASK_TOKEN_ID
+                budget = schedule[:, step_i]
+                mask_index_full = x == MASK_TOKEN_ID
+
+                # Use packed input for efficient forward
+                batch_size = x.size(0)
+                packed = []
+                cu_seqlens = [0]
+                max_seqlen = 0
+                for b in range(batch_size):
+                    valid = x[b][full_attn[b] == 1]
+                    packed.append(valid)
+                    cu_seqlens.append(cu_seqlens[-1] + len(valid))
+                    max_seqlen = max(max_seqlen, len(valid))
+                packed_input = torch.cat(packed, dim=0).unsqueeze(0)
+                cu_seqlens_t = torch.tensor(cu_seqlens, dtype=torch.int32, device=device)
+
+                if cfg_scale > 0.0:
+                    un_packed = packed_input.clone()
+                    for b in range(batch_size):
+                        plen = full_attn[b, :prompt_length].sum().item()
+                        un_packed[0, cu_seqlens[b]:cu_seqlens[b] + plen] = MASK_TOKEN_ID
+                    packed_cat = torch.cat([packed_input, un_packed], dim=0)
+                    cu_cat = torch.cat([cu_seqlens_t, cu_seqlens_t[1:] + cu_seqlens_t[-1]], dim=0)
+                    logits = model(packed_cat, cu_seqlens=cu_cat, max_seqlen=max_seqlen).logits
+                    logits, un_logits = torch.chunk(logits, 2, dim=0)
+                    logits = un_logits + (cfg_scale + 1) * (logits - un_logits)
+                else:
+                    logits = model(packed_input, cu_seqlens=cu_seqlens_t, max_seqlen=max_seqlen).logits
+
+                # Unpack logits to padded form
+                seq_len = x.size(1)
+                full_logits = torch.zeros(batch_size, seq_len, logits.size(-1), device=device, dtype=logits.dtype)
+                for b in range(batch_size):
+                    full_logits[b, full_attn[b] == 1] = logits[0, cu_seqlens[b]:cu_seqlens[b + 1]]
+
+                # Dream model requires shifted logits for correct token prediction
+                if self.model_name == 'dream':
+                    full_logits = torch.cat([full_logits[:, :1], full_logits[:, :-1]], dim=1)
+
+                logits_with_noise = add_gumbel_noise(full_logits, temperature)
+                x0 = torch.argmax(logits_with_noise, dim=-1)
+
+                if remasking == "low_confidence":
+                    p = torch.softmax(full_logits.float(), dim=-1)
+                    x0_p = torch.gather(p, dim=-1, index=x0.unsqueeze(-1)).squeeze(-1)
+                elif remasking == "random":
+                    x0_p = torch.rand_like(x0, dtype=torch.float32)
+                else:
+                    raise NotImplementedError(f"Remasking '{remasking}' not implemented")
+
+                x0_p[:, :start_idx] = -float('inf')
+                x0_p[:, end_idx:] = -float('inf')
+                x0 = torch.where(mask_index_full, x0, x)
+                confidence = torch.where(mask_index_full, x0_p, -torch.inf)
+
+                transfer_index = torch.zeros_like(x0, dtype=torch.bool, device=device)
+                for b in range(batch_size):
+                    k_plan = int(budget[b].item())
+                    if k_plan <= 0:
+                        continue
+                    k_avail = int(block_mask_step[b].sum().item())
+                    if k_avail <= 0:
+                        continue
+                    k = min(k_plan, k_avail)
+                    _, candidate_idx = torch.topk(confidence[b], k=k)
+                    transfer_index[b, candidate_idx] = True
+
+                transfer_index = transfer_index & ~prompt_index
+                x[transfer_index] = x0[transfer_index]
+
+            remaining_steps -= steps_in_this_block
+
+        return x

--- a/verl/workers/rollout/generation_utils_block.py
+++ b/verl/workers/rollout/generation_utils_block.py
@@ -581,7 +581,7 @@ class DreamGenerationMixin:
             current_block_end = current_block_start + block_length
 
             # update cache
-            model_output = self(x, attention_mask, tok_idx, use_cache=True)
+            model_output = self(input_ids=x, attention_mask=attention_mask, position_ids=tok_idx, use_cache=True)
             past_key_values = model_output.past_key_values
             logits = model_output.logits
             logits = torch.cat([logits[:, :1], logits[:, :-1]], dim=1)
@@ -625,15 +625,17 @@ class DreamGenerationMixin:
 
                 if dual_cache:
                     model_output = self(
-                        x[:, current_block_start:current_block_end], current_attention_mask,
-                        tok_idx[:, current_block_start:current_block_end] if tok_idx is not None else None,
+                        input_ids=x[:, current_block_start:current_block_end],
+                        attention_mask=current_attention_mask,
+                        position_ids=tok_idx[:, current_block_start:current_block_end] if tok_idx is not None else None,
                         past_key_values=past_key_values, use_cache=True,
                         dual_cache=dual_cache, replace_position=replace_position,
                     )
                 else:
                     model_output = self(
-                        x[:, current_block_start:], current_attention_mask,
-                        tok_idx[:, current_block_start:] if tok_idx is not None else None,
+                        input_ids=x[:, current_block_start:],
+                        attention_mask=current_attention_mask,
+                        position_ids=tok_idx[:, current_block_start:] if tok_idx is not None else None,
                         past_key_values=past_key_values, use_cache=True,
                     )
                 logits = model_output.logits


### PR DESCRIPTION
Hi, thank you for building and open-sourcing this excellent framework. It provides a very clean and convenient foundation for developing and evaluating new dllm rl methods.

In this PR, we integrate our proposed algorithm d-TreeRPO into this repository:

Paper: https://arxiv.org/abs/2512.09675

We have already tested the integration with LLaDA, and the training runs successfully. The reward curve for sudoku task is attached below.
<img width="1390" height="427" alt="image" src="https://github.com/user-attachments/assets/f1b99d89-d6fd-4627-808c-aafb93fb5fe8" />

At the same time, we noticed that training with the Dream model seems to be less stable. One possible reason is that Dream appears to have relatively weaker format-following ability, which may affect training stability in this framework. We are not yet sure whether this is expected behavior, so we would like to ask whether you have observed a similar issue on your side.

We would be very happy if this integration could be useful to the project, and we also welcome any suggestions or feedback.
